### PR TITLE
Fix checkdir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,8 @@ list(APPEND SOURCES
   ${CMAKE_CURRENT_LIST_DIR}/uEMEP_subgrid_emission_EMEP.f90
   ${CMAKE_CURRENT_LIST_DIR}/uEMEP_subgrid_meteo_EMEP.f90
   ${CMAKE_CURRENT_LIST_DIR}/uEMEP_tiling_routines.f90
-  ${CMAKE_CURRENT_LIST_DIR}/uEMEP_time_functions.f90)
+  ${CMAKE_CURRENT_LIST_DIR}/uEMEP_time_functions.f90
+  ${CMAKE_CURRENT_LIST_DIR}/io_functions.f90)
 
 # Include source files in sub-directories
 include(${CMAKE_CURRENT_LIST_DIR}/extern/CMakeLists.txt)

--- a/src/io_functions.f90
+++ b/src/io_functions.f90
@@ -13,18 +13,23 @@ contains
     function check_dir_exist(path) result(exists)
         !! Checks if a directory exists and/or if we have write permission
         !! in that directory.
-        !! 
-        !! The specific 'path' must end with '/'
         !!
         !! Returns .true. if directory exists and is accessible
         character(len=*), intent(in) :: path !! Directory path
         logical:: exists 
 
         ! Local variables
-        integer :: u, ios
+        integer :: u, ios, len_trimmed
+
+        ! Get length of directory path
+        len_trimmed = len_trim(path)
 
         ! Attempt to open a temporary file in the specified directory
-        open(newunit=u, file=path//"tmp", status="new", iostat=ios)
+        if (path(len_trimmed:len_trimmed) == "/") then
+            open(newunit=u, file=trim(path)//"tmp", status="new", iostat=ios)
+        else
+            open(newunit=u, file=trim(path)//"/tmp", status="new", iostat=ios)
+        end if
         if (ios /= 0) then
             exists = .false.
         else

--- a/src/io_functions.f90
+++ b/src/io_functions.f90
@@ -1,0 +1,37 @@
+module io_functions
+    !! This module contains procedures that support IO operations
+
+    use uEMEP_definitions, only: unit_logfile
+
+    implicit none
+    private
+
+    public :: check_dir_exist
+
+contains
+
+    function check_dir_exist(path) result(exists)
+        !! Checks if a directory exists and/or if we have write permission
+        !! in that directory.
+        !! 
+        !! The specific 'path' must end with '/'
+        !!
+        !! Returns .true. if directory exists and is accessible
+        character(len=*), intent(in) :: path !! Directory path
+        logical:: exists 
+
+        ! Local variables
+        integer :: u, ios
+
+        ! Attempt to open a temporary file in the specified directory
+        open(newunit=u, file=path//"tmp", status="new", iostat=ios)
+        if (ios /= 0) then
+            exists = .false.
+        else
+            ! If succesfull, delete the temporary file
+            close(unit=u, status="delete")
+            exists = .true.
+        end if
+    end function check_dir_exist
+
+end module io_functions

--- a/src/read_data/uEMEP_read_config.f90
+++ b/src/read_data/uEMEP_read_config.f90
@@ -7,6 +7,7 @@ module read_config
     use time_functions, only: date_to_datestr_bracket, date_to_number, &
         number_to_date, date_to_datestr_squarebracket, date_to_datestr, &
         datestr_to_date
+    use io_functions, only: check_dir_exist
 
     implicit none
     private
@@ -74,7 +75,7 @@ contains
                 if (len(trim(filename_log_file)).gt.0) then
                     unit_logfile=10
                     !Check existence of path
-                    inquire(file=trim(pathname_log_file),exist=exists)
+                    exists = check_dir_exist(path=trim(pathname_log_file))
                     if (.not.exists) then
                         write(unit_logfile,'(A)')'ERROR: Log file directory path '//trim(pathname_log_file)//' does not exist.'
                         stop

--- a/src/save_data/uEMEP_save_emission_netcdf.f90
+++ b/src/save_data/uEMEP_save_emission_netcdf.f90
@@ -18,6 +18,7 @@ module save_emission_netcdf
         datestr_to_date
     use grid_roads, only: uEMEP_grid_roads
     use mod_lambert_projection, only: lambert2lb2_uEMEP
+    use io_functions, only: check_dir_exist
 
     implicit none
     private
@@ -378,7 +379,7 @@ contains
         write(unit_logfile,'(A)') 'Saving emission netcdf data (uEMEP_save_emission_netcdf)'
         write(unit_logfile,'(A)') '================================================================'
 
-        inquire(file=trim(pathname_emissions_for_EMEP),exist=exists)
+        exists = check_dir_exist(path=trim(pathname_emissions_for_EMEP))
         if (.not.exists) then
             write(unit_logfile,'(A)')'ERROR: Path to EMEP emission output '//trim(pathname_emissions_for_EMEP)//' does not exist.'
             stop

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ foreach(execid
     read_namefile_routines
     time_functions
     uemep_logger
+    io_functions
     )
 
     add_executable(test_${execid} test/test_${execid}.f90)

--- a/test/test_io_functions.f90
+++ b/test/test_io_functions.f90
@@ -10,11 +10,11 @@ program test_io_functions
     ok = .true.
 
     ! Get current work directory
-    call get_command_argument(0, pwd)
+    call get_environment_variable("PWD", pwd)
     
     ! Test case 1 (check_dir_exist): Directory does not exist
     expected = .false.
-    result = check_dir_exist(path=pwd//"nothing_here/")
+    result = check_dir_exist(path=trim(pwd)//"/i_do_not_exist/")
     if (result /= expected) then
         ok = .false.
         print "(a)", "Test case 1 failed! Routine: check_dir_exist"
@@ -22,7 +22,7 @@ program test_io_functions
 
     ! Test case 2 (check_dir_exist): Directory exists
     expected = .true.
-    result = check_dir_exist(path=pwd)
+    result = check_dir_exist(path=trim(pwd))
     if (result /= expected) then
         ok = .false.
         print "(a)", "Test case 2 failed! Routine: check_dir_exist"

--- a/test/test_io_functions.f90
+++ b/test/test_io_functions.f90
@@ -1,0 +1,48 @@
+program test_io_functions
+
+    use io_functions
+
+    implicit none
+
+    ! Local variables
+    character(len=256) :: pwd
+    logical :: expected, result, ok
+    ok = .true.
+
+    ! Get current work directory
+    call get_command_argument(0, pwd)
+    
+    ! Test case 1 (check_dir_exist): Directory does not exist
+    expected = .false.
+    result = check_dir_exist(path=pwd//"nothing_here/")
+    if (result /= expected) then
+        ok = .false.
+        print "(a)", "Test case 1 failed! Routine: check_dir_exist"
+    end if
+
+    ! Test case 2 (check_dir_exist): Directory exists
+    expected = .true.
+    result = check_dir_exist(path=pwd)
+    if (result /= expected) then
+        ok = .false.
+        print "(a)", "Test case 2 failed! Routine: check_dir_exist"
+    end if
+
+    ! Test case 3 (check_dir_exist): Directory exist, but no write access
+    ! This will fail is tests are run as root!
+    expected = .false.
+    result = check_dir_exist(path="/")
+    if (result /= expected) then
+        ok = .false.
+        print "(a)", "Test case 3 failed! Routine: check_dir_exist"
+    end if
+
+    ! Return test results summary
+    if (ok) then
+        print "(a)", "test_io_functions: All tests passed."
+    else
+        print "(a)", "test_io_functions: One ore more tests failed."
+        stop 1
+    end if
+    
+end program test_io_functions


### PR DESCRIPTION
Added new module to hold utility functions for IO operations

Currently has only 1 function which will check if a directory exists and/or if we have proper write access. It solve the limitation of 'inquire' which behaves differently using ifort or gfortran. Also added a test program for the module/function.