### PR TITLE
Removed references to wrong model versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,6 @@ add_library(uemeplib ${SOURCES})
 include(test/CMakeLists.txt)
 
 # Build and link main executable
-add_executable(uemep src/uEMEP_control_v2.f90)
+add_executable(uemep src/uEMEP_main.f90)
 target_link_libraries(uemep PRIVATE uemeplib ${NC_LIB})
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Air quality dispersion model for high resolution downscaling of EMEP MSC-W
 This Github repository contains the source code for the uEMEP model.
 
 ## This version
-Version 7.0.0
+Version 7.0.1
 
 ## Installation
 

--- a/src/uEMEP_main.f90
+++ b/src/uEMEP_main.f90
@@ -1,6 +1,6 @@
-program uEMEP_v6
+program uEMEP
     !! ****************************************************************************
-    !!   uEMEP control v2
+    !!   uEMEP
     !!
     !!   Bruce rolstad Denby (brucerd@met.no)
     !!   MET Norway
@@ -78,7 +78,7 @@ program uEMEP_v6
     call cpu_Time(start_time_cpu)
 
         ! Set model version
-    model_version_str='7.0.0'
+    model_version_str='7.0.1'
 
     ! Check command line arguments and handle special cases that have to be printed to stdout
     call check_command_line()
@@ -507,5 +507,5 @@ program uEMEP_v6
     write(*,'(a,i5,a,i2)') ' CPU time taken (MM:SS): ', floor((end_time_cpu - start_time_cpu)/60.0),':', floor(mod(end_time_cpu - start_time_cpu, 60.0))
     write(*,*) '------------------------------------------------------------------------'
 
-end program uEMEP_v6
+end program uEMEP
 


### PR DESCRIPTION
Removed references to wrong model versions.

- Changed the main program file name to remove reference to version 2
- Updated program file name in CMakeLists.txt
- Changed the main program name to remove reference to version 6
- Bumped current version to 7.0.1