### PR TITLE
Handle special case when nonlocal NOx is zero

### DIFF
--- a/src/chemistry/uEMEP_chemistry_NO2.f90
+++ b/src/chemistry/uEMEP_chemistry_NO2.f90
@@ -574,13 +574,19 @@ contains
                                     else
                                         f_no2_isource = f_no2_emep
                                     end if
-                                    ! calculate NO2/NOx ratio in the background
-                                    f_no2_bg = no2_bg / nox_bg
-                                    ! get semilocal contribution to NOx from this source
-                                    nox_semiloc_isource = subgrid_EMEP_semilocal_from_in_region(i,j,t,i_source,pollutant_loop_back_index(nox_index))
-                                    ! calculate NO2 and O3 semilocal contribution from the source, assuming the NO2/NOx ratio is the same as in background
-                                    comp_semilocal_source_subgrid_from_in_region(i,j,t,no2_index,i_source) = f_no2_bg * nox_semiloc_isource
-                                    comp_semilocal_source_subgrid_from_in_region(i,j,t,o3_index,i_source) = -48./46.*(f_no2_bg - f_no2_isource) * nox_semiloc_isource
+                                    if (nox_bg > epsilon0) then
+                                        ! calculate NO2/NOx ratio in the background
+                                        f_no2_bg = min(1.0, max(0.0, no2_bg / nox_bg))
+                                        ! get semilocal contribution to NOx from this source
+                                        nox_semiloc_isource = subgrid_EMEP_semilocal_from_in_region(i,j,t,i_source,pollutant_loop_back_index(nox_index))
+                                        ! calculate NO2 and O3 semilocal contribution from the source, assuming the NO2/NOx ratio is the same as in background
+                                        comp_semilocal_source_subgrid_from_in_region(i,j,t,no2_index,i_source) = f_no2_bg * nox_semiloc_isource
+                                        comp_semilocal_source_subgrid_from_in_region(i,j,t,o3_index,i_source) = -48./46.*(f_no2_bg - f_no2_isource) * nox_semiloc_isource
+                                    else
+                                        ! special case: if NOx background is too small, set all semilocal contributions to zero too
+                                        comp_semilocal_source_subgrid_from_in_region(i,j,t,no2_index,i_source) = 0.0
+                                        comp_semilocal_source_subgrid_from_in_region(i,j,t,o3_index,i_source) = 0.0
+                                    end if
                                 end if
                             end do
 


### PR DESCRIPTION
This merge fixes a bug that occurred in the calculation of NO2 and O3 semilocal contributions (i.e. contributions from EMEP from outside the moving window but inside the region) if nonlocal NOx is zero. The zero nonlocal NOx occurs rarely (in Norwegian calculations at least) and is in turn a numerical artifact caused by the (unphysical) situation where the sum of NOx Local Fraction values from the EMEP model is larger than 1, which is again related to using the 2nd order Bott scheme for vertical advection of Local Fractions in the EMEP model. The bug was fixed by setting the semilocal contributions to 0 when nonlocal NOx is less than epsilon0. At the same time, I also added an upper limit of 1 and a lower limit of 0 to the ratio of NO2/NOx semilocal contribution, which could otherwise be outside this range due to numerical issues.