### PR TITLE
Avoid that round-off errors cause test of equidistant coordinates in region mask to fail

### DIFF
--- a/src/uEMEP_auto_subgrid.f90
+++ b/src/uEMEP_auto_subgrid.f90
@@ -5,6 +5,7 @@ module auto_subgrid
     use mod_area_interpolation, only: area_weighted_interpolation_function
     use mod_lambert_projection, only: LL2PROJ, PROJ2LL
     use netcdf
+    use uemep_constants, only: epsilon0
 
     implicit none
     private
@@ -474,8 +475,8 @@ contains
         integer region_mask_projection_type
         double precision region_mask_projection_attributes(10)
         ! the x and y coordinates
-        real, allocatable :: x_values_regionmask(:)
-        real, allocatable :: y_values_regionmask(:)
+        double precision, allocatable :: x_values_regionmask(:)
+        double precision, allocatable :: y_values_regionmask(:)
         ! the region ID data themselves
         integer, allocatable :: region_mask(:, :)
         ! assumed names for dimensions of the region mask file
@@ -483,7 +484,7 @@ contains
         ! length of dimensions of the region mask
         integer nx_regionmask,ny_regionmask
         ! grid spacing of the region mask (to be verified is constant!)
-        real dx_regionmask,dy_regionmask
+        double precision dx_regionmask,dy_regionmask
         ! subset needed to read from the region mask file
         real x_min,x_max,y_min,y_max
         integer x_min_index,x_max_index,y_min_index,y_max_index
@@ -636,14 +637,14 @@ contains
         ! Determine grid spacing and verify it is constant
         dx_regionmask = x_values_regionmask(2) - x_values_regionmask(1)
         do i = 2, nx_regionmask
-            if (.not. (x_values_regionmask(i) - x_values_regionmask(i-1) == dx_regionmask)) then
+            if (.not. (abs((x_values_regionmask(i) - x_values_regionmask(i-1) - dx_regionmask) / dx_regionmask) < epsilon0)) then
                 write(unit_logfile,'(A)') 'Not constant spacing in x coordinate in region mask'
                 stop
             end if
         end do
         dy_regionmask = y_values_regionmask(2) - y_values_regionmask(1)
         do i = 2, ny_regionmask
-            if (.not. (y_values_regionmask(i) - y_values_regionmask(i-1) == dy_regionmask)) then
+            if (.not. (abs((y_values_regionmask(i) - y_values_regionmask(i-1) - dy_regionmask) / dy_regionmask) < epsilon0)) then
                 write(unit_logfile,'(A)') 'Not constant spacing in y coordinate in region mask'
                 stop
             end if

--- a/src/uEMEP_auto_subgrid.f90
+++ b/src/uEMEP_auto_subgrid.f90
@@ -5,7 +5,7 @@ module auto_subgrid
     use mod_area_interpolation, only: area_weighted_interpolation_function
     use mod_lambert_projection, only: LL2PROJ, PROJ2LL
     use netcdf
-    use uemep_constants, only: epsilon0
+    use uemep_constants, only: epsilon0, dp
 
     implicit none
     private
@@ -473,10 +473,10 @@ contains
         integer temp_num_dims
         ! projection of the region mask
         integer region_mask_projection_type
-        double precision region_mask_projection_attributes(10)
+        real(dp) region_mask_projection_attributes(10)
         ! the x and y coordinates
-        double precision, allocatable :: x_values_regionmask(:)
-        double precision, allocatable :: y_values_regionmask(:)
+        real(dp), allocatable :: x_values_regionmask(:)
+        real(dp), allocatable :: y_values_regionmask(:)
         ! the region ID data themselves
         integer, allocatable :: region_mask(:, :)
         ! assumed names for dimensions of the region mask file
@@ -484,7 +484,7 @@ contains
         ! length of dimensions of the region mask
         integer nx_regionmask,ny_regionmask
         ! grid spacing of the region mask (to be verified is constant!)
-        double precision dx_regionmask,dy_regionmask
+        real(dp) dx_regionmask,dy_regionmask
         ! subset needed to read from the region mask file
         real x_min,x_max,y_min,y_max
         integer x_min_index,x_max_index,y_min_index,y_max_index
@@ -637,14 +637,14 @@ contains
         ! Determine grid spacing and verify it is constant
         dx_regionmask = x_values_regionmask(2) - x_values_regionmask(1)
         do i = 2, nx_regionmask
-            if (.not. (abs((x_values_regionmask(i) - x_values_regionmask(i-1) - dx_regionmask) / dx_regionmask) < epsilon0)) then
+            if (abs((x_values_regionmask(i) - x_values_regionmask(i-1) - dx_regionmask) / dx_regionmask) > epsilon0) then
                 write(unit_logfile,'(A)') 'Not constant spacing in x coordinate in region mask'
                 stop
             end if
         end do
         dy_regionmask = y_values_regionmask(2) - y_values_regionmask(1)
         do i = 2, ny_regionmask
-            if (.not. (abs((y_values_regionmask(i) - y_values_regionmask(i-1) - dy_regionmask) / dy_regionmask) < epsilon0)) then
+            if (abs((y_values_regionmask(i) - y_values_regionmask(i-1) - dy_regionmask) / dy_regionmask) > epsilon0) then
                 write(unit_logfile,'(A)') 'Not constant spacing in y coordinate in region mask'
                 stop
             end if

--- a/src/uEMEP_subgrid_EMEP.f90
+++ b/src/uEMEP_subgrid_EMEP.f90
@@ -1893,8 +1893,9 @@ contains
                 ! fractional position inside the EMEP grid (center is (0,0), lower-left corner is (-0.5,-0.5), upper-right corner is (+0.5,+0.5))
                 ii_frac_target = (x_temp-var1d_nc(ii,x_dim_nc_index))/dgrid_nc(x_dim_nc_index)
                 jj_frac_target = (y_temp-var1d_nc(jj,y_dim_nc_index))/dgrid_nc(y_dim_nc_index)
-                ! verify that this is within 0-1 (if not, crossreference has gone wrong...)
-                if (ii_frac_target < -0.51 .or. ii_frac_target > 0.51 .or. jj_frac_target < -0.51 .or. jj_frac_target > 0.51) then
+                ! verify that this is within [-0.5, 0.5] (if not, crossreference has gone wrong...)
+                ! However, allow for a bit of round-off error, so set limits to +/-0.51
+                if (abs(ii_frac_target) > 0.51 .or. abs(jj_frac_target) > 0.51) then
                     write(unit_logfile,'(A,2I5,A,2F18.10)') 'Something went wrong with locating target subgrid within EMEP grid! At (i,j)=',i,j,'fractions are',ii_frac_target,jj_frac_target
                     stop
                 end if

--- a/src/uEMEP_subgrid_EMEP.f90
+++ b/src/uEMEP_subgrid_EMEP.f90
@@ -1894,8 +1894,8 @@ contains
                 ii_frac_target = (x_temp-var1d_nc(ii,x_dim_nc_index))/dgrid_nc(x_dim_nc_index)
                 jj_frac_target = (y_temp-var1d_nc(jj,y_dim_nc_index))/dgrid_nc(y_dim_nc_index)
                 ! verify that this is within 0-1 (if not, crossreference has gone wrong...)
-                if (ii_frac_target < -0.5 .or. ii_frac_target > 0.5 .or. jj_frac_target < -0.5 .or. jj_frac_target > 0.5) then
-                    write(unit_logfile,'(A,2I12)') 'Something went wrong with locating target subgrid within EMEP grid!',ii_frac_target,jj_frac_target
+                if (ii_frac_target < -0.51 .or. ii_frac_target > 0.51 .or. jj_frac_target < -0.51 .or. jj_frac_target > 0.51) then
+                    write(unit_logfile,'(A,2I5,A,2F18.10)') 'Something went wrong with locating target subgrid within EMEP grid! At (i,j)=',i,j,'fractions are',ii_frac_target,jj_frac_target
                     stop
                 end if
 


### PR DESCRIPTION
In the test that coordinate values of the region mask file are equidistant, allow relative differences of up to epsilon0, since we may have round-off errors in decimal numbers. Also use double-precision when reading the coordinate values to avoid too large round-off errors. Also allow for some round-of error in the check during interpolation in uEMEP_subgrid_EMEP.