### PR TITLE
Refactored the area interpolation functions module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 list(APPEND SOURCES
   ${CMAKE_CURRENT_LIST_DIR}/utility_functions.f90
   ${CMAKE_CURRENT_LIST_DIR}/uEMEP_definitions.f90
-  ${CMAKE_CURRENT_LIST_DIR}/Area_weighted_interpolation_function.f90
+  ${CMAKE_CURRENT_LIST_DIR}/area_interpolation_functions.f90
   ${CMAKE_CURRENT_LIST_DIR}/lambert_projection.f90
   ${CMAKE_CURRENT_LIST_DIR}/read_esri_ascii_file.f90
   ${CMAKE_CURRENT_LIST_DIR}/uEMEP_aggregate_proxy_emission_in_EMEP_grid.f90

--- a/src/area_interpolation_functions.f90
+++ b/src/area_interpolation_functions.f90
@@ -51,7 +51,7 @@ contains
             do jjj = j-1, j+1
                 do iii = i-1, i+1
                     jj = max(jjj,1); jj = min(jj,ydim)
-                    ii = max(iii,1); ii = min(jj,xdim)
+                    ii = max(iii,1); ii = min(ii,xdim)
                     xpos_min = max(xpos_area_min, xgrid(ii,jj) - delta(1)/2.0)
                     xpos_max = min(xpos_area_max, xgrid(ii,jj) + delta(1)/2.0)
                     ypos_min = max(ypos_area_min, ygrid(ii,jj) - delta(2)/2.0)

--- a/src/area_interpolation_functions.f90
+++ b/src/area_interpolation_functions.f90
@@ -9,34 +9,44 @@ module area_interpolation_functions
 
 contains
 
-    function area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval) result(res)
-        !! Returns the area weight value for a a point at position xval, yval from the grid values xgrid,ygrid,zgrid
-        integer, intent(in) :: xdim, ydim
-        real, intent(in) :: delta(2)
-        real, intent(in) :: xgrid(xdim,ydim), ygrid(xdim,ydim), zgrid(xdim,ydim)
-        real, intent(in) :: xval, yval
-        real :: res
+    function area_weighted_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval) result(res)
+        !! Returns the area weighted value for a point with fixed delta
+        !!
+        !! This function performs an area-weighted interpolation to estimate the value of a field 
+        !! at a specific point `(xval, yval)` based on a grid of values (`zgrid`) and positions
+        !! (`xgrid` and `ygrid`)
+        !!
+        !! If no valid weights are found (`sum_weight == 0.0`), the function returns `0.0`
+        real, intent(in) :: xgrid(:,:) !! Array of x-coordinates of the grid points
+        real, intent(in) :: ygrid(:,:) !! Array of y-coordinates of the grid points
+        real, intent(in) :: zgrid(:,:) !! Array of values at each grid point to be interpolated
+        real, intent(in) :: delta(2) !! Array specifying the grid resolution
+        real, intent(in) :: xval !! The x-coordinate of the target point for interpolation
+        real, intent(in) :: yval !! The y-coordinate of the target point for interpolation
+        real :: res !! Interpolated value of `zgrid` at point `(xval, yval)`
 
         ! Local variables
-        real :: zval
-        real :: sum_weight
-
-        real :: weighting
+        integer :: xdim, ydim
         integer :: i, j, ii, jj, iii, jjj
+        real :: zval, sum_weight, weighting
         real :: xpos_area_max, xpos_area_min, ypos_area_max, ypos_area_min
         real :: xpos_max, xpos_min, ypos_max, ypos_min
 
+        ! Find the size of the arrays
+        xdim = size(xgrid, 1)
+        ydim = size(xgrid, 2)
+
         ! If only on grid available then return the value of that grid
-        if (xdim .eq. 1 .and. ydim .eq. 1) then
+        if (xdim == 1 .and. ydim == 1) then
             res = zgrid(xdim,ydim)
             return
-        endif
+        end if
 
         ! Find grid index for position val
         i = 1 + floor((xval - xgrid(1,1))/delta(1) + 0.5)
         j = 1 + floor((yval - ygrid(1,1))/delta(2) + 0.5)
 
-        if (i .lt. 1 .or. j .lt. 1 .or. i .gt. xdim .or. j .gt. ydim) then
+        if (i < 1 .or. j < 1 .or. i > xdim .or. j > ydim) then
             write(*,'(A,4i6)') 'Interpolation out of range in area_weighted_interpolation_function. Stopping. (i,j,xdim,ydim)', i, j, xdim, ydim
             write(*,'(4f12.2)') xval, yval, xgrid(1,1), ygrid(1,1)
             stop 1
@@ -57,54 +67,67 @@ contains
                     ypos_min = max(ypos_area_min, ygrid(ii,jj) - delta(2)/2.0)
                     ypos_max = min(ypos_area_max, ygrid(ii,jj) + delta(2)/2.0)
 
-                    if (xpos_max .gt. xpos_min .and. ypos_max .gt. ypos_min) then
+                    if (xpos_max > xpos_min .and. ypos_max > ypos_min) then
                         weighting = (ypos_max - ypos_min)*(xpos_max - xpos_min)/delta(1)/delta(2)
                     else
                         weighting = 0.0
-                    endif
-                    zval=zval+zgrid(ii,jj)*weighting
-                    sum_weight=sum_weight+weighting
-                enddo
-            enddo
-        endif
+                    end if
+
+                    zval = zval + zgrid(ii,jj)*weighting
+                    sum_weight = sum_weight + weighting
+                end do
+            end do
+        end if
         if (sum_weight > 0.0) then
-            res = zval / sum_weight
+            res = zval/sum_weight
         else
             res = 0.0
         end if
     end function area_weighted_interpolation_function
 
-    function area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val) result(res)
-        !! Returns the area weighted value for rectangle of size delta_val at position xval, yval from the grid values xgrid,ygrid,zgrid
-        !! Delta_val can be any size
-        integer, intent(in) :: xdim, ydim
-        real, intent(in) :: delta(2)
-        real, intent(in) :: delta_val(2)
-        real, intent(in) :: xgrid(xdim,ydim), ygrid(xdim,ydim), zgrid(xdim,ydim)
-        real, intent(in) :: xval, yval
-        real :: res
+    function area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval, delta_val) result(res)
+        !! Returns the area weighted value for a point with variable delta
+        !!
+        !! This function performs an area-weighted interpolation to estimate the value of a field
+        !! at a specific point `(xval,yval)` within an rectangle `delta_val(2)` based on grid of
+        !! values (`zgrid`) and positions (`xgrid` and `ygrid`)
+        !!
+        !! If no valid weights are found (`sum_weight == 0.0`), the function returns `0.0`
+        real, intent(in) :: xgrid(:,:) !! Array of x-coordinates of the grid points
+        real, intent(in) :: ygrid(:,:) !! Array of y-coordinates of the grid points
+        real, intent(in) :: zgrid(:,:) !! Array of values at each grid point to be interpolated
+        real, intent(in) :: delta(2) !! Array specifying the grid resolution
+        real, intent(in) :: delta_val(2) !! Array specifying the size of the grid used for interpolation
+        real, intent(in) :: xval !! The x-coordinate of the target point for interpolation
+        real, intent(in) :: yval !! The y-coordinate of the target point for interpolation
+        real :: res !! Interpolated value of `zgrid` at point `(xval, yval)`
 
         ! Local variables
         real :: zval, sum_weight, weighting
         real :: xpos_max, xpos_min, ypos_max, ypos_min
         real :: xpos_area_max, xpos_area_min, ypos_area_max, ypos_area_min
+        integer :: xdim, ydim
         integer :: i, j, ii, jj, iii, jjj
         integer :: ii_delta, jj_delta
 
+        ! Find the size of the arrays
+        xdim = size(xgrid, 1)
+        ydim = size(ygrid, 2)
+
         ! If only on grid available then return the value of that grid
-        if (xdim .eq. 1 .and. ydim .eq. 1) then
+        if (xdim == 1 .and. ydim == 1) then
             res = zgrid(xdim,ydim)
             return
-        endif
+        end if
 
         ! Find grid index for position val
         i = 1 + floor((xval - xgrid(1,1))/delta(1) + 0.5)
         j = 1 + floor((yval - ygrid(1,1))/delta(2) + 0.5)
 
-        if (i .lt. 1 .or. j .lt. 1 .or. i .gt. xdim .or. j .gt. ydim) then
+        if (i < 1 .or. j < 1 .or. i > xdim .or. j > ydim) then
             write(*,'(A,4i6)') 'Interpolation out of range in area_weighted_extended_interpolation_function. Stopping. (i,j,xdim,ydim)', i, j, xdim, ydim
             write(*,'(4f12.2)') xval, yval, xgrid(1,1), ygrid(1,1)
-            stop
+            stop 1
         else
             xpos_area_max = xval + delta_val(1)/2.0
             xpos_area_min = xval - delta_val(1)/2.0
@@ -125,52 +148,63 @@ contains
                     ypos_min = max(ypos_area_min, ygrid(ii,jj) - delta(2)/2.0)
                     ypos_max = min(ypos_area_max, ygrid(ii,jj) + delta(2)/2.0)
 
-                    if (xpos_max .gt. xpos_min .and. ypos_max .gt. ypos_min) then
+                    if (xpos_max > xpos_min .and. ypos_max > ypos_min) then
                         weighting = (ypos_max - ypos_min)*(xpos_max - xpos_min)/delta_val(1)/delta_val(2)
                     else
                         weighting = 0.0
                     endif
                     zval = zval + zgrid(ii,jj)*weighting
                     sum_weight = sum_weight + weighting
-                enddo
-            enddo
-        endif
+                end do
+            end do
+        end if
         if (sum_weight > 0.0) then
-            res = zval / sum_weight
+            res = zval/sum_weight
         else
             res = 0.0
-        endif
+        end if
     end function area_weighted_extended_interpolation_function
 
-    function area_weighted_extended_vectorgrid_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val) result(res)
-        !! Returns the area weighted value for rectangle of size delta_val at position xval, yval from the grid values xgrid,ygrid,zgrid
-        !! Delta_val can be any size
-        !! vectorgrid means the grid positions only have one dimension
-        integer, intent(in) :: xdim, ydim
-        real, intent(in) :: delta(2)
-        real, intent(in) :: delta_val(2)
-        real, intent(in) :: xgrid(xdim), ygrid(ydim), zgrid(xdim,ydim)
-        real, intent(in) :: xval, yval
-        real :: res
+    function area_weighted_extended_vectorgrid_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval, delta_val) result(res)
+        !! Returns the area weighted value for a point with variable delta (vector version)
+        !!
+        !! This function performs an area-weighted interpolation to estimate the value of a field
+        !! at a specific point `(xval,yval)` within an rectangle `delta_val(2)` based on grid of
+        !! values (`zgrid`) and vectors of positions (`xgrid` and `ygrid`)
+        !!
+        !! If no valid weights are found (`sum_weight == 0.0`), the function returns `0.0`
+        real, intent(in) :: xgrid(:) !! Vector of x-coordinates of the grid points
+        real, intent(in) :: ygrid(:) !! Vector of y-coordinates of the grid points
+        real, intent(in) :: zgrid(:,:) !! Array of values at each grid point to be interpolated
+        real, intent(in) :: delta(2) !! Array specifying the grid resolution
+        real, intent(in) :: delta_val(2) !! Array specifying the size of the grid used for interpolation
+        real, intent(in) :: xval !! The x-coordinate of the target point for interpolation
+        real, intent(in) :: yval !! The y-coordinate of the target point for interpolation
+        real :: res !! Interpolated value of `zgrid` at point `(xval, yval)`
 
         ! Local variables
         real :: zval, sum_weight, weighting
-        real :: xpos_area_max,xpos_area_min,ypos_area_max,ypos_area_min
-        real :: xpos_max,xpos_min,ypos_max,ypos_min
+        real :: xpos_area_max, xpos_area_min, ypos_area_max, ypos_area_min
+        real :: xpos_max, xpos_min, ypos_max, ypos_min
+        integer :: xdim, ydim
         integer :: i, j, ii, jj, iii, jjj
         integer :: ii_delta, jj_delta
 
+        ! Find the size of the arrays
+        xdim = size(xgrid)
+        ydim = size(ygrid)
+
         ! If only on grid available then return the value of that grid
-        if (xdim .eq. 1 .and. ydim .eq. 1) then
+        if (xdim == 1 .and. ydim == 1) then
             res = zgrid(xdim,ydim)
             return
-        endif
+        end if
 
         ! Find grid index for position val
         i = 1 + floor((xval-xgrid(1))/delta(1) + 0.5)
         j = 1 + floor((yval-ygrid(1))/delta(2) + 0.5)
 
-        if (i .lt. 1 .or. j .lt. 1 .or. i .gt. xdim .or. j .gt. ydim) then
+        if (i < 1 .or. j < 1 .or. i > xdim .or. j > ydim) then
             write(*,'(A,4i6)') 'Interpolation out of range in area_weighted_extended_interpolation_function. Stopping. (i,j,xdim,ydim)', i, j, xdim, ydim
             write(*,'(4f12.2)') xval, yval, xgrid(1), ygrid(1)
             stop
@@ -194,18 +228,19 @@ contains
                     ypos_min = max(ypos_area_min, ygrid(jj) - delta(2)/2.0)
                     ypos_max = min(ypos_area_max, ygrid(jj) + delta(2)/2.0)
 
-                    if (xpos_max .gt. xpos_min .and. ypos_max .gt. ypos_min) then
+                    if (xpos_max > xpos_min .and. ypos_max > ypos_min) then
                         weighting = (ypos_max - ypos_min)*(xpos_max - xpos_min)/delta_val(1)/delta_val(2)
                     else
                         weighting = 0.0
-                    endif
+                    end if
+
                     zval = zval + zgrid(ii,jj)*weighting
                     sum_weight = sum_weight + weighting
-                enddo
-            enddo
-        endif
+                end do
+            end do
+        end if
         if (sum_weight > 0.0) then
-            res = zval / sum_weight
+            res = zval/sum_weight
         else
             res = 0.0
         end if

--- a/src/area_interpolation_functions.f90
+++ b/src/area_interpolation_functions.f90
@@ -1,4 +1,4 @@
-module mod_area_interpolation
+module area_interpolation_functions
 
     implicit none
     private
@@ -206,5 +206,5 @@ contains
         res = zval
     end function area_weighted_extended_vectorgrid_interpolation_function
 
-end module mod_area_interpolation
+end module area_interpolation_functions
 

--- a/src/area_interpolation_functions.f90
+++ b/src/area_interpolation_functions.f90
@@ -22,7 +22,7 @@ contains
         real :: sum_weight
 
         real :: weighting
-        integer :: i, j, ii, jj
+        integer :: i, j, ii, jj, iii, jjj
         real :: xpos_area_max, xpos_area_min, ypos_area_max, ypos_area_min
         real :: xpos_max, xpos_min, ypos_max, ypos_min
 
@@ -35,8 +35,6 @@ contains
         ! Find grid index for position val
         i = 1 + floor((xval - xgrid(1,1))/delta(1) + 0.5)
         j = 1 + floor((yval - ygrid(1,1))/delta(2) + 0.5)
-        i = max(1,i); i = min(xdim,i)
-        j = max(1,j); j = min(ydim,j)
 
         if (i .lt. 1 .or. j .lt. 1 .or. i .gt. xdim .or. j .gt. ydim) then
             write(*,'(A,4i6)') 'Interpolation out of range in area_weighted_interpolation_function. Stopping. (i,j,xdim,ydim)', i, j, xdim, ydim
@@ -50,9 +48,10 @@ contains
 
             zval = 0.0
             sum_weight = 0.0
-
-            do jj = j-1, j+1
-                do ii = i-1, i+1
+            do jjj = j-1, j+1
+                do iii = i-1, i+1
+                    jj = max(jjj,1); jj = min(jj,ydim)
+                    ii = max(iii,1); ii = min(jj,xdim)
                     xpos_min = max(xpos_area_min, xgrid(ii,jj) - delta(1)/2.0)
                     xpos_max = min(xpos_area_max, xgrid(ii,jj) + delta(1)/2.0)
                     ypos_min = max(ypos_area_min, ygrid(ii,jj) - delta(2)/2.0)
@@ -68,8 +67,11 @@ contains
                 enddo
             enddo
         endif
-
-        res = zval
+        if (sum_weight > 0.0) then
+            res = zval / sum_weight
+        else
+            res = 0.0
+        end if
     end function area_weighted_interpolation_function
 
     function area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val) result(res)
@@ -98,8 +100,6 @@ contains
         ! Find grid index for position val
         i = 1 + floor((xval - xgrid(1,1))/delta(1) + 0.5)
         j = 1 + floor((yval - ygrid(1,1))/delta(2) + 0.5)
-        i = max(1,i); i = min(xdim,i)
-        j = max(1,j); j = min(ydim,j)
 
         if (i .lt. 1 .or. j .lt. 1 .or. i .gt. xdim .or. j .gt. ydim) then
             write(*,'(A,4i6)') 'Interpolation out of range in area_weighted_extended_interpolation_function. Stopping. (i,j,xdim,ydim)', i, j, xdim, ydim
@@ -135,7 +135,11 @@ contains
                 enddo
             enddo
         endif
-        res = zval
+        if (sum_weight > 0.0) then
+            res = zval / sum_weight
+        else
+            res = 0.0
+        endif
     end function area_weighted_extended_interpolation_function
 
     function area_weighted_extended_vectorgrid_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val) result(res)
@@ -165,9 +169,6 @@ contains
         ! Find grid index for position val
         i = 1 + floor((xval-xgrid(1))/delta(1) + 0.5)
         j = 1 + floor((yval-ygrid(1))/delta(2) + 0.5)
-
-        i = max(1,i); i = min(xdim,i)
-        j = max(1,j); j = min(ydim,j)
 
         if (i .lt. 1 .or. j .lt. 1 .or. i .gt. xdim .or. j .gt. ydim) then
             write(*,'(A,4i6)') 'Interpolation out of range in area_weighted_extended_interpolation_function. Stopping. (i,j,xdim,ydim)', i, j, xdim, ydim
@@ -203,7 +204,11 @@ contains
                 enddo
             enddo
         endif
-        res = zval
+        if (sum_weight > 0.0) then
+            res = zval / sum_weight
+        else
+            res = 0.0
+        end if
     end function area_weighted_extended_vectorgrid_interpolation_function
 
 end module area_interpolation_functions

--- a/src/area_interpolation_functions.f90
+++ b/src/area_interpolation_functions.f90
@@ -1,4 +1,5 @@
 module area_interpolation_functions
+    !! The module provides functions for performing area-weighted intepolations on 2D grids.
 
     implicit none
     private

--- a/src/read_data/uEMEP_read_SSB_data.f90
+++ b/src/read_data/uEMEP_read_SSB_data.f90
@@ -3,7 +3,7 @@ module read_ssb_data
     use uemep_configuration
     use utility_functions, only: ll2utm, ll2ltm
     use mod_lambert_projection, only: LL2LAEA, PROJ2LL
-    use mod_area_interpolation, only: area_weighted_extended_vectorgrid_interpolation_function
+    use area_interpolation_functions, only: area_weighted_extended_vectorgrid_interpolation_function
 
     implicit none
     private

--- a/src/read_data/uEMEP_read_SSB_data.f90
+++ b/src/read_data/uEMEP_read_SSB_data.f90
@@ -837,7 +837,7 @@ contains
                         !Do the interpolation on the same grid then scale afterwards. Equivalent to interpolating density then rescaling with grid size
                         population_subgrid(i,j,SSB_data_type)=area_weighted_extended_vectorgrid_interpolation_function( &
                             real(var2d_nc_dp(1:dim_length_population_nc(x_dim_nc_index),x_dim_nc_index))*correct_lon(1),real(var2d_nc_dp(1:dim_length_population_nc(y_dim_nc_index),y_dim_nc_index)) &
-                            ,population_nc_dp(:,:,population_nc_index),dim_length_population_nc(x_dim_nc_index),dim_length_population_nc(y_dim_nc_index) &
+                            ,population_nc_dp(:,:,population_nc_index) &
                             ,delta_pop_nc*correct_lon,temp_lon(1)*correct_lon(1),temp_lat(1),delta_pop_nc*correct_lon)
 
                         temp_scale=(temp_delta(1)*correct_lon(1)*temp_delta(2)*correct_lon(2))/(delta_pop_nc(1)*correct_lon(1)*delta_pop_nc(2)*correct_lon(2))
@@ -884,7 +884,7 @@ contains
                         !Interpolate on same grid then scale, equivalent to interpolating density and then recalculating
                         proxy_emission_subgrid(i,j,source_index,:)=area_weighted_extended_vectorgrid_interpolation_function( &
                             real(var2d_nc_dp(1:dim_length_population_nc(x_dim_nc_index),x_dim_nc_index))*correct_lon(1),real(var2d_nc_dp(1:dim_length_population_nc(y_dim_nc_index),y_dim_nc_index)) &
-                            ,population_nc_dp(:,:,population_nc_index),dim_length_population_nc(x_dim_nc_index),dim_length_population_nc(y_dim_nc_index) &
+                            ,population_nc_dp(:,:,population_nc_index) &
                             ,delta_pop_nc*correct_lon,temp_lon(1)*correct_lon(1),temp_lat(1),delta_pop_nc*correct_lon)
 
                         temp_scale=(temp_delta(1)*correct_lon(1)*temp_delta(2)*correct_lon(2))/(delta_pop_nc(1)*correct_lon(1)*delta_pop_nc(2)*correct_lon(2))

--- a/src/read_data/uEMEP_read_agriculture_rivm_data.f90
+++ b/src/read_data/uEMEP_read_agriculture_rivm_data.f90
@@ -199,7 +199,7 @@ contains
                     do i=i_start,i_end
                         do j=j_start,j_end
                             if (i.gt.1.and.i.lt.emission_subgrid_dim(x_dim_index,source_index).and.j.gt.1.and.j.lt.emission_subgrid_dim(y_dim_index,source_index)) then
-                                temp_emission=area_weighted_extended_interpolation_function(x_temp,y_temp,z_temp,3,3, &
+                                temp_emission=area_weighted_extended_interpolation_function(x_temp,y_temp,z_temp, &
                                     nh3_gridsize,x_emission_subgrid(i,j,source_index),y_emission_subgrid(i,j,source_index),emission_subgrid_delta(:,source_index))
                                 proxy_emission_subgrid(i,j,source_index,pollutant_loop_back_index(nh3_nc_index))= &
                                     proxy_emission_subgrid(i,j,source_index,pollutant_loop_back_index(nh3_nc_index))+temp_emission*nh3emission_scale

--- a/src/read_data/uEMEP_read_agriculture_rivm_data.f90
+++ b/src/read_data/uEMEP_read_agriculture_rivm_data.f90
@@ -2,7 +2,7 @@ module read_agriculture_asi_data
 
     use uemep_configuration
     use mod_lambert_projection, only: lb2lambert2_uEMEP, LL2PS_spherical
-    use mod_area_interpolation, only: area_weighted_extended_interpolation_function
+    use area_interpolation_functions, only: area_weighted_extended_interpolation_function
 
     implicit none
     private

--- a/src/read_data/uEMEP_read_shipping_asi_data.f90
+++ b/src/read_data/uEMEP_read_shipping_asi_data.f90
@@ -725,7 +725,7 @@ contains
                     !Interpolate on same grid then scale, equivalent to interpolating density and then recalculating
                     proxy_emission_subgrid(i,j,source_index,:)=area_weighted_extended_vectorgrid_interpolation_function( &
                         real(var2d_nc_dp(1:dim_length_shipping_nc(x_dim_nc_index),x_dim_nc_index))*correct_lon(1),real(var2d_nc_dp(1:dim_length_shipping_nc(y_dim_nc_index),y_dim_nc_index)) &
-                        ,shipping_nc_dp(:,:,i_ship),dim_length_shipping_nc(x_dim_nc_index),dim_length_shipping_nc(y_dim_nc_index) &
+                        ,shipping_nc_dp(:,:,i_ship) &
                         ,delta_shipping_nc*correct_lon,temp_lon(1)*correct_lon(1),temp_lat(1),delta_shipping_nc*correct_lon)
 
                     temp_scale=(temp_delta(1)*correct_lon(1)*temp_delta(2)*correct_lon(2))/(delta_shipping_nc(1)*correct_lon(1)*delta_shipping_nc(2)*correct_lon(2))

--- a/src/read_data/uEMEP_read_shipping_asi_data.f90
+++ b/src/read_data/uEMEP_read_shipping_asi_data.f90
@@ -4,7 +4,7 @@ module read_shipping_asi_data
     use utility_functions, only: nxtdat, ll2utm, ll2ltm, utm2ll
     use time_functions, only: datestr_to_date, date_to_number, number_to_date
     use mod_lambert_projection, only: PROJ2LL, lb2lambert2_uEMEP, LL2PS_spherical, LL2LAEA
-    use mod_area_interpolation, only: area_weighted_extended_vectorgrid_interpolation_function
+    use area_interpolation_functions, only: area_weighted_extended_vectorgrid_interpolation_function
 
     implicit none
     private

--- a/src/save_data/uEMEP_save_netcdf_file.f90
+++ b/src/save_data/uEMEP_save_netcdf_file.f90
@@ -3,7 +3,7 @@ module save_netcdf_file
     use uemep_configuration
     use chemistry_no2, only: uEMEP_source_fraction_chemistry
     use mod_read_esri_ascii_file, only: write_esri_ascii_file
-    use mod_area_interpolation, only: area_weighted_interpolation_function
+    use area_interpolation_functions, only: area_weighted_interpolation_function
 
     implicit none
     private

--- a/src/save_data/uEMEP_save_netcdf_file.f90
+++ b/src/save_data/uEMEP_save_netcdf_file.f90
@@ -2682,7 +2682,7 @@ contains
         delta(2)=(y_array(1,2)-y_array(1,1))
         do rr=1,nr
             do tr=1,nt
-                val_rec(rr,tr)=area_weighted_interpolation_function(x_array,y_array,val_array(:,:,tr),nx,ny,delta,x_rec(rr),y_rec(rr))
+                val_rec(rr,tr)=area_weighted_interpolation_function(x_array,y_array,val_array(:,:,tr),delta,x_rec(rr),y_rec(rr))
             enddo
         enddo
 

--- a/src/uEMEP_auto_subgrid.f90
+++ b/src/uEMEP_auto_subgrid.f90
@@ -271,7 +271,7 @@ contains
                                                 end if
                                             end do
                                         end do
-                                        subgrid(i,j,t,proxy_subgrid_index,i_source,i_pollutant)=area_weighted_interpolation_function(xgrid,ygrid,zgrid,xdim,ydim,delta,xval,yval)
+                                        subgrid(i,j,t,proxy_subgrid_index,i_source,i_pollutant)=area_weighted_interpolation_function(xgrid,ygrid,zgrid,delta,xval,yval)
 
                                         ! Travel time interpolation as well
                                         do jj = 1, 3
@@ -284,7 +284,7 @@ contains
                                                 end if
                                             end do
                                         end do
-                                        traveltime_subgrid(i,j,t,1,i_pollutant) = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+                                        traveltime_subgrid(i,j,t,1,i_pollutant) = area_weighted_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval)
 
                                         do jj = 1, 3
                                             do ii = 1, 3
@@ -296,7 +296,7 @@ contains
                                                 end if
                                             end do
                                         end do
-                                        traveltime_subgrid(i,j,t,2,i_pollutant) = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+                                        traveltime_subgrid(i,j,t,2,i_pollutant) = area_weighted_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval)
                                     end do
                                 end do
                             end if

--- a/src/uEMEP_auto_subgrid.f90
+++ b/src/uEMEP_auto_subgrid.f90
@@ -2,7 +2,7 @@ module auto_subgrid
 
     use uemep_configuration
     use uEMEP_definitions
-    use mod_area_interpolation, only: area_weighted_interpolation_function
+    use area_interpolation_functions, only: area_weighted_interpolation_function
     use mod_lambert_projection, only: LL2PROJ, PROJ2LL
     use netcdf
 

--- a/src/uEMEP_subgrid_deposition.f90
+++ b/src/uEMEP_subgrid_deposition.f90
@@ -10,7 +10,7 @@ module subgrid_deposition
         gauss_plume_cartesian_sigma_func
     use kz_functions, only: z_centremass_gauss_func, u_profile_neutral_val_func, &
         uEMEP_set_dispersion_sigma_Kz
-    use mod_area_interpolation, only: area_weighted_interpolation_function, &
+    use area_interpolation_functions, only: area_weighted_interpolation_function, &
         area_weighted_extended_interpolation_function
     use mod_rargsort, only: rargsort
 

--- a/src/uEMEP_subgrid_deposition.f90
+++ b/src/uEMEP_subgrid_deposition.f90
@@ -257,7 +257,7 @@ contains
                             do i_pollutant=1,n_pollutant_loop
                                 target_deposition_subgrid(ii,jj,vd_index,i_pollutant)=target_deposition_subgrid(ii,jj,vd_index,i_pollutant)+ &
                                     area_weighted_extended_interpolation_function(x_deposition_subgrid,y_deposition_subgrid,deposition_subgrid(:,:,tt,vd_index,i_pollutant) &
-                                    ,deposition_subgrid_dim(x_dim_index),deposition_subgrid_dim(y_dim_index),deposition_subgrid_delta(:),x_target_subgrid(ii,jj),y_target_subgrid(ii,jj),target_subgrid_delta)
+                                    ,deposition_subgrid_delta(:),x_target_subgrid(ii,jj),y_target_subgrid(ii,jj),target_subgrid_delta)
                             enddo
                         enddo
                     enddo
@@ -619,20 +619,20 @@ contains
                             if (calculate_deposition_flag) then
                                 subgrid(i,j,tt,drydepo_local_subgrid_index,source_index,i_pollutant)=subgrid(i,j,tt,drydepo_local_subgrid_index,source_index,i_pollutant) &
                                     +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,target_deposition_subgrid(:,:,drydepo_index,i_pollutant) &
-                                    ,target_subgrid_dim(x_dim_index),target_subgrid_dim(y_dim_index),target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
+                                    ,target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
                                 subgrid(i,j,tt,wetdepo_local_subgrid_index,source_index,i_pollutant)=subgrid(i,j,tt,wetdepo_local_subgrid_index,source_index,i_pollutant) &
                                     +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,target_deposition_subgrid(:,:,wetdepo_index,i_pollutant) &
-                                    ,target_subgrid_dim(x_dim_index),target_subgrid_dim(y_dim_index),target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
+                                    ,target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
                             endif
                             subgrid(i,j,tt,proxy_subgrid_index,source_index,i_pollutant)=subgrid(i,j,tt,proxy_subgrid_index,source_index,i_pollutant) &
                                 +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,target_subgrid(:,:,i_pollutant) &
-                                ,target_subgrid_dim(x_dim_index),target_subgrid_dim(y_dim_index),target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
+                                ,target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
                             traveltime_subgrid(i,j,tt,1,i_pollutant)=traveltime_subgrid(i,j,tt,1,i_pollutant) &
                                 +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,traveltime_target_subgrid(:,:,1,i_pollutant) &
-                                ,target_subgrid_dim(x_dim_index),target_subgrid_dim(y_dim_index),target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
+                                ,target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
                             traveltime_subgrid(i,j,tt,2,i_pollutant)=traveltime_subgrid(i,j,tt,2,i_pollutant) &
                                 +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,traveltime_target_subgrid(:,:,2,i_pollutant) &
-                                ,target_subgrid_dim(x_dim_index),emission_max_subgrid_dim(y_dim_index),target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
+                                ,target_subgrid_delta(:),x_subgrid(i,j),y_subgrid(i,j))
                         enddo
                     else
                         subgrid(i,j,tt,proxy_subgrid_index,source_index,:)=NODATA_value
@@ -660,7 +660,7 @@ contains
                             do i_pollutant=1,n_pollutant_loop
                                 integral_subgrid(i,j,tt,i_integral,source_index,i_pollutant)=integral_subgrid(i,j,tt,i_integral,source_index,i_pollutant) &
                                     +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,target_vertical_integral_subgrid(:,:,i_integral) &
-                                    ,target_subgrid_dim(x_dim_index),target_subgrid_dim(y_dim_index),target_subgrid_delta(:),x_integral_subgrid(i,j),y_integral_subgrid(i,j))
+                                    ,target_subgrid_delta(:),x_integral_subgrid(i,j),y_integral_subgrid(i,j))
                                 !write(*,*) i,j,i_integral,integral_subgrid(i,j,tt,i_integral,source_index,i_pollutant)
                             enddo
                         enddo

--- a/src/uEMEP_subgrid_deposition_EMEP.f90
+++ b/src/uEMEP_subgrid_deposition_EMEP.f90
@@ -119,9 +119,9 @@ contains
                     do i_pollutant=1,n_pollutant_loop
                         do tt=1,subgrid_dim(t_dim_index)
                             temp(tt,2)=area_weighted_extended_interpolation_function(x_integral_subgrid,y_integral_subgrid,integral_subgrid(:,:,tt,hmix_integral_subgrid_index,i_source,i_pollutant) &
-                                ,integral_subgrid_dim(x_dim_index),integral_subgrid_dim(y_dim_index),integral_subgrid_delta(x_dim_index),x_subgrid(i,j),y_subgrid(i,j),delta_area)
+                                ,integral_subgrid_delta(x_dim_index),x_subgrid(i,j),y_subgrid(i,j),delta_area)
                             temp(tt,1)=area_weighted_extended_interpolation_function(x_integral_subgrid,y_integral_subgrid,integral_subgrid(:,:,tt,hsurf_integral_subgrid_index,i_source,i_pollutant) &
-                                ,integral_subgrid_dim(x_dim_index),integral_subgrid_dim(y_dim_index),integral_subgrid_delta(x_dim_index),x_subgrid(i,j),y_subgrid(i,j),delta_area)
+                                ,integral_subgrid_delta(x_dim_index),x_subgrid(i,j),y_subgrid(i,j),delta_area)
 
                             !ratio(tt,i_source,i_pollutant)=temp(tt,2)/temp(tt,1)*H_emep/h_mix_loc(tt)
                             ratio(tt,i_source,i_pollutant)=temp(tt,2)/temp(tt,1)*H_emep/h_mix_loc(tt)

--- a/src/uEMEP_subgrid_deposition_EMEP.f90
+++ b/src/uEMEP_subgrid_deposition_EMEP.f90
@@ -1,7 +1,7 @@
 module subgrid_deposition_emep
 
     use uemep_configuration
-    use mod_area_interpolation, only: area_weighted_extended_interpolation_function
+    use area_interpolation_functions, only: area_weighted_extended_interpolation_function
 
     implicit none
     private

--- a/src/uEMEP_subgrid_dispersion.f90
+++ b/src/uEMEP_subgrid_dispersion.f90
@@ -14,7 +14,7 @@ module subgrid_dispersion
         gauss_plume_second_order_rotated_integral_func
     use kz_functions, only: z_centremass_gauss_func, u_profile_neutral_val_func, &
         uEMEP_set_dispersion_sigma_Kz
-    use mod_area_interpolation, only: area_weighted_interpolation_function
+    use area_interpolation_functions, only: area_weighted_interpolation_function
 
     implicit none
     private

--- a/src/uEMEP_subgrid_dispersion.f90
+++ b/src/uEMEP_subgrid_dispersion.f90
@@ -1024,13 +1024,13 @@ contains
                             if (use_subgrid(i,j,source_index)) then
                                 do i_pollutant=1,n_pollutant_loop
                                     temp_subgrid(i,j,i_pollutant)=area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,temp_target_subgrid(:,:,i_pollutant) &
-                                        ,emission_max_subgrid_dim(x_dim_index),emission_max_subgrid_dim(y_dim_index),emission_subgrid_delta(:,source_index),x_subgrid(i,j),y_subgrid(i,j))
+                                        ,emission_subgrid_delta(:,source_index),x_subgrid(i,j),y_subgrid(i,j))
                                     traveltime_subgrid(i,j,tt,1,i_pollutant)=traveltime_subgrid(i,j,tt,1,i_pollutant) &
                                         +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,traveltime_temp_target_subgrid(:,:,1,i_pollutant) &
-                                        ,emission_max_subgrid_dim(x_dim_index),emission_max_subgrid_dim(y_dim_index),emission_subgrid_delta(:,source_index),x_subgrid(i,j),y_subgrid(i,j))
+                                        ,emission_subgrid_delta(:,source_index),x_subgrid(i,j),y_subgrid(i,j))
                                     traveltime_subgrid(i,j,tt,2,i_pollutant)=traveltime_subgrid(i,j,tt,2,i_pollutant) &
                                         +area_weighted_interpolation_function(x_target_subgrid,y_target_subgrid,traveltime_temp_target_subgrid(:,:,2,i_pollutant) &
-                                        ,emission_max_subgrid_dim(x_dim_index),emission_max_subgrid_dim(y_dim_index),emission_subgrid_delta(:,source_index),x_subgrid(i,j),y_subgrid(i,j))
+                                        ,emission_subgrid_delta(:,source_index),x_subgrid(i,j),y_subgrid(i,j))
                                     !write(*,*) tt,i,j,temp_subgrid(i,j)
                                     ! New version of in-region, allowing target region to vary within the target grid
                                     ! ****************
@@ -1039,7 +1039,6 @@ contains
                                         i_region = regionindex_loop_back_index(subgrid_region_index(i,j))
                                         subgrid_from_in_region_new(i,j,i_pollutant) = area_weighted_interpolation_function( &
                                             x_target_subgrid,y_target_subgrid,temp_target_subgrid_per_source_region(:,:,i_pollutant,i_region) &
-                                            ,emission_max_subgrid_dim(x_dim_index),emission_max_subgrid_dim(y_dim_index) &
                                             ,emission_subgrid_delta(:,source_index),x_subgrid(i,j),y_subgrid(i,j))
                                     end if
                                     ! ***************

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ foreach(execid
     time_functions
     uemep_logger
     io_functions
+    area_interpolation_functions
     )
 
     add_executable(test_${execid} test/test_${execid}.f90)

--- a/test/test_area_interpolation_functions.f90
+++ b/test/test_area_interpolation_functions.f90
@@ -29,7 +29,7 @@ program test_area_interpolation_functions
     xval = 2.0
     yval = 2.0
     expected = 50.0
-    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 1 failed! Routine: area_weighted_interpolation_function"
@@ -39,7 +39,7 @@ program test_area_interpolation_functions
     xval = 0.50001
     yval = 0.50001
     expected = 10.0
-    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 2 failed! Routine: area_weighted_interpolation_function"
@@ -49,7 +49,7 @@ program test_area_interpolation_functions
     xval = 3.49999
     yval = 3.49999
     expected = 90.0
-    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 3 failed! Routine: area_weighted_interpolation_function"
@@ -60,7 +60,7 @@ program test_area_interpolation_functions
     yval = 2.0
     delta_val = [2.0, 2.0]
     expected = 50.0
-    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 4 failed! Routine: area_weighted_extended_interpolation_function"
@@ -70,7 +70,7 @@ program test_area_interpolation_functions
     xval = 0.50001
     yval = 0.50001
     expected = 10.0002
-    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 5 failed! Routine: area_weighted_extended_interpolation_function"
@@ -80,7 +80,7 @@ program test_area_interpolation_functions
     xval = 3.49999
     yval = 3.49999
     expected = 89.99980
-    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 6 failed! Routine: area_weighted_extended_interpolation_function"
@@ -91,7 +91,7 @@ program test_area_interpolation_functions
     yval = 1.8
     delta_val = [1.0, 1.0]
     expected = 45.5
-    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 7 failed! Routine: area_weighted_extended_interpolation_function"
@@ -102,7 +102,7 @@ program test_area_interpolation_functions
     yval = 2.0
     delta_val = [2.0, 2.0]
     expected = 50.0
-    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 8 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"
@@ -112,7 +112,7 @@ program test_area_interpolation_functions
     xval = 0.50001
     yval = 0.50001
     expected = 10.0002
-    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 9 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"
@@ -122,7 +122,7 @@ program test_area_interpolation_functions
     xval = 3.49999
     yval = 3.49999
     expected = 89.99980
-    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 10 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"
@@ -133,7 +133,7 @@ program test_area_interpolation_functions
     yval = 1.93
     delta_val = [1.0, 1.0]
     expected = 46.7
-    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, delta, xval, yval, delta_val)
     if (abs(result - expected) > 1.0e-5) then
         ok = .false.
         print "(a)", "Test case 11 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"

--- a/test/test_area_interpolation_functions.f90
+++ b/test/test_area_interpolation_functions.f90
@@ -1,0 +1,150 @@
+program test_area_interpolation_functions
+
+    use area_interpolation_functions
+
+    implicit none
+
+    real :: xgrid(3,3), ygrid(3,3), zgrid(3,3), delta(2), delta_val(2)
+    real :: xgrid_vec(3), ygrid_vec(3)
+    real :: xval, yval, result, expected
+    logical :: ok
+    integer :: xdim, ydim
+
+    ok = .true.
+    xdim = 3
+    ydim = 3
+
+    ! Define a simple grid for testing
+    xgrid = reshape([1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0], shape(xgrid))
+    ygrid = reshape([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0], shape(ygrid))
+    zgrid = reshape([10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0], shape(zgrid))
+    delta = [1.0, 1.0]
+    delta_val = [1.0, 1.0]
+
+    ! Define vector grids for testing
+    xgrid_vec = [1.0, 2.0, 3.0]
+    ygrid_vec = [1.0, 2.0, 3.0]
+
+    ! Test case 1: Point-based area interpolation in the center of the grid
+    xval = 2.0
+    yval = 2.0
+    expected = 50.0
+    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 1 failed! Routine: area_weighted_interpolation_function"
+    end if
+
+    ! Test case 2: Point-based area interpolation at the upper-left edge of the grid
+    xval = 0.50001
+    yval = 0.50001
+    expected = 10.0
+    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 2 failed! Routine: area_weighted_interpolation_function"
+    end if
+
+    ! Test case 3: Point-based area interpolation at the lower-right edge of the grid
+    xval = 3.49999
+    yval = 3.49999
+    expected = 90.0
+    result = area_weighted_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 3 failed! Routine: area_weighted_interpolation_function"
+    end if
+
+    ! Test case 4: Rectangle-based area interpolation in the center of the grid
+    xval = 2.0
+    yval = 2.0
+    delta_val = [2.0, 2.0]
+    expected = 50.0
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 4 failed! Routine: area_weighted_extended_interpolation_function"
+    end if
+
+    ! Test case 5: Rectangle-based area interpolation at the upper-left edge of the grid
+    xval = 0.50001
+    yval = 0.50001
+    expected = 10.0002
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 5 failed! Routine: area_weighted_extended_interpolation_function"
+    end if
+
+    ! Test case 6: Rectangle-based area interpolation at the lower-right edge of the grid
+    xval = 3.49999
+    yval = 3.49999
+    expected = 89.99980
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 6 failed! Routine: area_weighted_extended_interpolation_function"
+    end if
+
+    ! Test case 7: Rectangle-based area interpolation with smaller delta_val
+    xval = 2.15
+    yval = 1.8
+    delta_val = [1.0, 1.0]
+    expected = 45.5
+    result = area_weighted_extended_interpolation_function(xgrid, ygrid, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 7 failed! Routine: area_weighted_extended_interpolation_function"
+    end if
+
+    ! Test case 8: Vector-based area interpolation in the center of the grid
+    xval = 2.0
+    yval = 2.0
+    delta_val = [2.0, 2.0]
+    expected = 50.0
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 8 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"
+    end if
+
+    ! Test case 9: Vector-based area interpolation at the upper-left edge of the grid
+    xval = 0.50001
+    yval = 0.50001
+    expected = 10.0002
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 9 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"
+    end if
+
+    ! Test case 10: Vector-based area interpolation at the lower-right edge of the grid
+    xval = 3.49999
+    yval = 3.49999
+    expected = 89.99980
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 10 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"
+    end if
+
+    ! Test case 11: Vector-based area interpolation using smaller delta_val
+    xval = 1.88
+    yval = 1.93
+    delta_val = [1.0, 1.0]
+    expected = 46.7
+    result = area_weighted_extended_vectorgrid_interpolation_function(xgrid_vec, ygrid_vec, zgrid, xdim, ydim, delta, xval, yval, delta_val)
+    if (abs(result - expected) > 1.0e-5) then
+        ok = .false.
+        print "(a)", "Test case 11 failed! Routine: area_weighted_extended_vectorgrid_interpolation_function"
+    end if
+
+    ! Return the test results summary
+    if (ok) then
+        print "(a)", "test_area_interpolation_functions: All tests passed."
+    else
+        print "(a)", "test_area_interpolation_functions: One or more tests failed."
+        stop 1
+    end if
+
+end program test_area_interpolation_functions


### PR DESCRIPTION
Refactored the area interpolation functions module

1. Changed name of file and module
2. Added FORD documentation to module and all function
3. Changed input arrays to assumed shape instead of explicitly setting size
   - Removed dimensions from argument list (now derived from input arrays)
   - Updated function calls to reflect this
4. Re-enabled position check
   - All functions will now stop the program if interpolation point is outside the subgrid
5. Fixed bug that produced wrong weighs and values at the edge of the grid
   - All function now divide by the sum of weights which will be > 1 if at the grid edge
   - The interpolated value will thus approach the edge value as we approach the edge
6. Updated to reflect coding style
7. New unit test. Test both center and edge positions cases for all functions.

The code passes unit testing and regression tests (https://gitlab.met.no/emep/uemep-testing).