### PR TITLE
Change default value for 'ratio_truck_car_emission' for all compounds to 15.0

### DIFF
--- a/src/global/uemep_configuration.f90
+++ b/src/global/uemep_configuration.f90
@@ -278,7 +278,7 @@ module uemep_configuration
     real :: hmix_min = 25.0
     real :: hmix_max = 2000.0
     real :: emission_factor(n_compound_nc_index, n_source_index, n_possible_subsource) = 1.0
-    real :: ratio_truck_car_emission(n_compound_nc_index) = 15.0  ! August 2025: change from 10.0 to 15.0
+    real :: ratio_truck_car_emission(n_compound_nc_index) = 15.0
     real :: z_rec(n_source_index, n_possible_subsource) ! Pseudo dispersion parameters
     real :: ay(n_source_index, n_possible_subsource) ! Pseudo dispersion parameters
     real :: replace_invL = NODATA_value  ! Will not replace invL when it has a NODATA value

--- a/src/global/uemep_configuration.f90
+++ b/src/global/uemep_configuration.f90
@@ -278,7 +278,7 @@ module uemep_configuration
     real :: hmix_min = 25.0
     real :: hmix_max = 2000.0
     real :: emission_factor(n_compound_nc_index, n_source_index, n_possible_subsource) = 1.0
-    real :: ratio_truck_car_emission(n_compound_nc_index) = 10.0
+    real :: ratio_truck_car_emission(n_compound_nc_index) = 15.0  ! August 2025: change from 10.0 to 15.0
     real :: z_rec(n_source_index, n_possible_subsource) ! Pseudo dispersion parameters
     real :: ay(n_source_index, n_possible_subsource) ! Pseudo dispersion parameters
     real :: replace_invL = NODATA_value  ! Will not replace invL when it has a NODATA value

--- a/src/uEMEP_set_constants.f90
+++ b/src/uEMEP_set_constants.f90
@@ -568,13 +568,6 @@ contains
         emission_factor(nh3_index,agriculture_index,:)=1. !Agriculture data is in emissions [kg/yr]
         emission_factor(nh4_index,agriculture_index,:)=1. !Agriculture data is in emissions [kg/yr]
 
-        ! As of August 2025, no longer modify ratio_truck_car_emission for individual components. Let it stay at value 15 for all (as set in uemep_configuration.f90)
-        !ratio_truck_car_emission(nox_index)=12.5 !4.86/.318 !From excel sheet for NOx. 12.5 matches the values used in NORTRIP
-        !ratio_truck_car_emission(no2_index)=12.5 !4.86/.318 !Should perhaps be different but
-        !ratio_truck_car_emission(pm25_index)=10.
-        !ratio_truck_car_emission(pm10_index)=10.
-        !ratio_truck_car_emission(pmex_index)=10.
-
         !Set AQI thresholds
         aqi_hourly_limits(no2_index,1)=100.;aqi_hourly_limits(no2_index,2)=200.;aqi_hourly_limits(no2_index,3)=400.;
         !aqi_hourly_limits(pm10_index,1)=50.;aqi_hourly_limits(pm10_index,2)=80.;aqi_hourly_limits(pm10_index,3)=400.;

--- a/src/uEMEP_set_constants.f90
+++ b/src/uEMEP_set_constants.f90
@@ -568,11 +568,12 @@ contains
         emission_factor(nh3_index,agriculture_index,:)=1. !Agriculture data is in emissions [kg/yr]
         emission_factor(nh4_index,agriculture_index,:)=1. !Agriculture data is in emissions [kg/yr]
 
-        ratio_truck_car_emission(nox_index)=12.5 !4.86/.318 !From excel sheet for NOx. 12.5 matches the values used in NORTRIP
-        ratio_truck_car_emission(no2_index)=12.5 !4.86/.318 !Should perhaps be different but
-        ratio_truck_car_emission(pm25_index)=10.
-        ratio_truck_car_emission(pm10_index)=10.
-        ratio_truck_car_emission(pmex_index)=10.
+        ! As of August 2025, no longer modify ratio_truck_car_emission for individual components. Let it stay at value 15 for all (as set in uemep_configuration.f90)
+        !ratio_truck_car_emission(nox_index)=12.5 !4.86/.318 !From excel sheet for NOx. 12.5 matches the values used in NORTRIP
+        !ratio_truck_car_emission(no2_index)=12.5 !4.86/.318 !Should perhaps be different but
+        !ratio_truck_car_emission(pm25_index)=10.
+        !ratio_truck_car_emission(pm10_index)=10.
+        !ratio_truck_car_emission(pmex_index)=10.
 
         !Set AQI thresholds
         aqi_hourly_limits(no2_index,1)=100.;aqi_hourly_limits(no2_index,2)=200.;aqi_hourly_limits(no2_index,3)=400.;


### PR DESCRIPTION
When using NORTRIP emissions, config option "ratio_truck_car_emission" does not affect emissions, but it is used to calculate traffic-induced turbulence and hence affects initial dispersion.

The default for this config was previously set to 12.5 for nox and no2 and 10.0 for all other compounds. However, we now use 15 and Bruce says this should be the norm. Therefore we want to change the default to be 15. Then these config parameters no longer need to be set in the config files.