### PR TITLE
Add Coverage build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,13 @@ project(uemep)
 # Enable testing
 enable_testing()
 
-# Hardcode ifort as the Fortran compiler (gfortran currently does not work)
-set(CMAKE_Fortran_COMPILER "ifort")
-#set(CMAKE_Fortran_COMPILER "gfortran")
+# Set fortran compiler
+if(DEFINED ENV{FF})
+  set(CMAKE_Fortran_COMPILER "$ENV{FF}" CACHE STRING "Fortran compiler set via FF environment variable" FORCE)
+else()
+  set(CMAKE_Fortran_COMPILER "ifort")
+endif()
+message(STATUS "Using Fortran compiler: ${CMAKE_Fortran_COMPILER}")
 enable_language(Fortran)
 
 # Append additional cmake modules
@@ -30,6 +34,15 @@ endif()
 # Set compiler flags
 set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} ${F90DEBUGFLAGS} ${F90DIALECT} ${F90DISABLE}")
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${F90FLAGS} ${F90DIALECT} ${F90DISABLE}")
+
+# Custom build type for coverage
+if(CMAKE_BUILD_TYPE MATCHES "Coverage")
+  if(CMAKE_Fortran_COMPILER MATCHES "gfortran")
+    set(CMAKE_Fortran_FLAGS "-ffree-form -fimplicit-none -O0 -fbacktrace -g -fprofile-arcs -ftest-coverage -fno-inline -ffree-line-length-none -fdec")
+  else()
+    message(FATAL_ERROR "The 'Coverage' build type currently requires the gfortran compiler")
+  endif()
+endif()
 
 # Import NetCDF
 find_package(NetCDF REQUIRED)

--- a/README.md
+++ b/README.md
@@ -12,13 +12,19 @@ git clone https://github.com/metno/uEMEP.git
 cd uEMEP
 mkdir -p build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=<build-type> ..
 make
 ```
 
-Note: uEMEP supports building source files in parallel, e.g., `make -j 4`.
+> Note: uEMEP supports building source files in parallel, e.g., `make -j 4`.
 
-Compilation requires an Intel Fortran compiler and a compatible NetCDF installation.
+Compilation uses the Intel Fortran compiler (ifort) by default requires a compatible NetCDF installation. To use `gfortran` instead if `ifort`, the compiler can be prepended as:
+
+```bash
+FF=gfortran cmake -DCMAKE_BUILD_TYPE=<build-type> ..
+```
+
+There are currently three different build types, `Release`, `Debug` and `Coverage`. See the top level `CMakeLists.txt` file for the compiler flags used. The `Coverage` build type is a special build for assessing code coverage using `gcov` and currently requires the `gfortran` compiler version >= 14.
 
 ## Testing
 


### PR DESCRIPTION
Adds coverage build type:
- Allows setting `-DCMAKE_BUILD_TYPE=Coverage` to compile with the necessary flags for assessing code coverage using `gcov`
- It requires `gfortran` version >=14 and will fail with an error message if `ifort` (the default) is used
- Added the capability for setting the Fortran compiler when running `cmake`, i.e., `FF=gfortran cmake ...`
- Updated the README to reflect these changes