### PR TITLE
Fix bug in NO2 and O3 source contributions with flag "use_annual_mean_pdf_chemistry_correction"

### DIFF
--- a/src/chemistry/uEMEP_chemistry_NO2.f90
+++ b/src/chemistry/uEMEP_chemistry_NO2.f90
@@ -1035,6 +1035,10 @@ contains
         integer :: no2_count
         logical :: run_all_flag
 
+        ! Ratio of corrected concentrations to original uncorrected concentrations (needed for scaling source contributions)
+        ! NB: for convenience, this array has a source dimension, but the scale factor will not vary along this dimension
+        real, allocatable :: comp_source_subgrid_scalefactor(:, :, :, :, :)
+
         write(unit_logfile,'(A)') ''
         write(unit_logfile,'(A)') '================================================================'
         write(unit_logfile,'(A)') 'Correcting annual mean NO2 and O3 (correct_annual_mean_chemistry)'
@@ -1070,6 +1074,12 @@ contains
                 run_all_flag = .true.
             end if
 
+            ! Initialize scale factor to 1 everywhere
+            if (save_no2_source_contributions .or. save_o3_source_contributions) then
+                allocate(comp_source_subgrid_scalefactor(subgrid_dim(x_dim_index),subgrid_dim(y_dim_index),subgrid_dim(t_dim_index),n_compound_index,n_source_index))
+                comp_source_subgrid_scalefactor = 1
+            end if
+
             do j = 1, subgrid_dim(y_dim_index)
                 do i = 1, subgrid_dim(x_dim_index)
 
@@ -1096,6 +1106,10 @@ contains
 
                     comp_subgrid(i,j,t,o3_index) = o3_out
                     comp_subgrid(i,j,t,no2_index) = no2_out
+                    if (save_no2_source_contributions .or. save_o3_source_contributions) then
+                        if (abs(o3_in) > epsilon0) comp_source_subgrid_scalefactor(i,j,t,o3_index,:) = o3_out/o3_in
+                        if (abs(no2_in) > epsilon0) comp_source_subgrid_scalefactor(i,j,t,no2_index,:) = no2_out/no2_in
+                    end if
                     sum_no2_in = sum_no2_in + no2_in
                     sum_no2_out = sum_no2_out + no2_out
                     no2_count = no2_count + 1
@@ -1109,6 +1123,19 @@ contains
         end do
 
         write(unit_logfile,'(a,f12.4)') 'Average NO2 scaling with pdf correction = ',sum_no2_out/sum_no2_in
+
+        ! Renormalize NO2 and O3 source contributions to the new total concentrations
+        ! by applying the same scaling factor to all sources, both local and nonlocal
+        if (save_no2_source_contributions .or. save_o3_source_contributions) then
+            if (allocated(comp_source_subgrid)) comp_source_subgrid = comp_source_subgrid * comp_source_subgrid_scalefactor
+            if (allocated(comp_source_subgrid_from_in_region)) comp_source_subgrid_from_in_region = comp_source_subgrid_from_in_region * comp_source_subgrid_scalefactor
+            if (allocated(comp_source_additional_subgrid)) comp_source_additional_subgrid = comp_source_additional_subgrid * comp_source_subgrid_scalefactor
+            if (allocated(comp_source_EMEP_subgrid)) comp_source_EMEP_subgrid = comp_source_EMEP_subgrid * comp_source_subgrid_scalefactor
+            if (allocated(comp_source_EMEP_additional_subgrid)) comp_source_EMEP_additional_subgrid = comp_source_EMEP_additional_subgrid * comp_source_subgrid_scalefactor
+            if (allocated(comp_semilocal_source_subgrid_from_in_region)) comp_semilocal_source_subgrid_from_in_region = comp_semilocal_source_subgrid_from_in_region * comp_source_subgrid_scalefactor
+            if (allocated(comp_source_subgrid_scalefactor)) deallocate(comp_source_subgrid_scalefactor)
+        end if
+
     end subroutine correct_annual_mean_chemistry
 
     subroutine uEMEP_annual_mean_pdf_correction_NO2_O3(bin_min, bin_max, delta_log10_bin, run_all, no2_in, nox_in, o3_in, J_photo_in, temperature_in, ox_sigma_ratio_in, nox_sigma_ratio_in, lon_in, lat_in, no2_out, o3_out)

--- a/src/save_data/uEMEP_save_netcdf_file.f90
+++ b/src/save_data/uEMEP_save_netcdf_file.f90
@@ -1,7 +1,6 @@
 module save_netcdf_file
 
     use uemep_configuration
-    use chemistry_no2, only: uEMEP_source_fraction_chemistry
     use mod_read_esri_ascii_file, only: write_esri_ascii_file
     use area_interpolation_functions, only: area_weighted_interpolation_function
 
@@ -546,19 +545,10 @@ contains
         end do  ! source_domain_loop
 
 
-        ! Calculate and save NO2 and O3 source contributions
+        ! Save NO2 and O3 source contributions
         if (save_no2_source_contributions .or. save_o3_source_contributions) then
 
-            ! Calculate NO2 and O3 source contributions
-            if (EMEP_additional_grid_interpolation_size.gt.0) then
-                calculate_EMEP_additional_grid_flag=.true.
-                call uEMEP_source_fraction_chemistry
-            endif
-
-            calculate_EMEP_additional_grid_flag=.false.
-            call uEMEP_source_fraction_chemistry
-
-            ! Save the contributions to file
+            ! Save different versions of the source contributions to file
             ! 1 = normal source contributions from within moving window
             ! 2 = source contributions cut down to region
             ! 3 = additional nonlocal
@@ -923,7 +913,7 @@ contains
         end if
 
         !Save the EMEP data interpolated to the subgrid. These are based on the gridded concentrations
-        ! Loop over 5 different verions
+        ! Loop over 6 different verions
         ! 1 = emep local contributions from the moving-window (downscaling domain)
         ! 2 = As 1, but only the part of the moving window that is within the receptor region
         ! 3 = emep additional local contributions, extending further using larger LF grid

--- a/src/uEMEP_main.f90
+++ b/src/uEMEP_main.f90
@@ -59,7 +59,7 @@ program uEMEP
     use subgrid_emission_emep, only: uEMEP_subgrid_emission_EMEP
     use subgrid_meteo_emep, only: uEMEP_subgrid_meteo_EMEP
     use tiling_routines, only: uEMEP_set_tile_grids, uEMEP_set_region_tile_grids
-    use chemistry_no2, only: uEMEP_chemistry, correct_annual_mean_chemistry
+    use chemistry_no2, only: uEMEP_chemistry, uEMEP_source_fraction_chemistry, correct_annual_mean_chemistry
     use crossreference_grids, only: uEMEP_crossreference_grids
     use grid_roads, only: uEMEP_grid_roads
     use define_subgrid, only: uEMEP_define_subgrid_extent, uEMEP_define_subgrid
@@ -450,6 +450,15 @@ program uEMEP
 
                 ! Calculate chemistry for NO2 and O3
                 call uEMEP_chemistry()
+                ! Calculate NO2 and O3 source contributions
+                if (save_no2_source_contributions .or. save_o3_source_contributions) then
+                    if (EMEP_additional_grid_interpolation_size.gt.0) then
+                        calculate_EMEP_additional_grid_flag=.true.
+                        call uEMEP_source_fraction_chemistry
+                    endif
+                    calculate_EMEP_additional_grid_flag=.false.
+                    call uEMEP_source_fraction_chemistry
+                end if
 
                 ! Correct annual mean chemistry for pdf
                 if (use_annual_mean_pdf_chemistry_correction) then


### PR DESCRIPTION
The subroutine "uEMEP_source_fraction_chemistry" calculates NO2 and O3 source contributions by removing one NOx source at a time and reapplying the NO2 chemistry scheme and then considering the shift in total concentration. Until now, this subroutine was called right before writing to file, inside subroutine "uEMEP_save_netcdf_control". When the flag "use_annual_mean_pdf_chemistry_correction" is active, then the total concentrations are modified right after the chemistry calculation (before source calculation). However, subroutine "uEMEP_source_fraction_chemistry" does not apply the PDF chemistry correction to the new concentration with one source removed at a time. This means that the effect on the concentration by the PDF correction was wrongly attributed to each source, and we could for instance get a non-zero NO2 contribution from a source with zero NOx contribution.

To avoid this bug, the NO2 and O3 source contributions should be calculated *before* the annual PDF chemistry correction is applied. The PDF chemistry correction modifies the total NO2 and O3 concentrations, so it is necessary to adjust the source contributions to ensure that the contributions add up to the new total. This is done assuming the correction should impact all sources equally (including non-local), so they are all multiplied by the same factor. This factor is the ratio of the corrected total concentration to the uncorrercted total concentration. 

Technical implementation in the code:
1. "uEMEP_source_fraction_chemistry" is no longer called inside "uEMEP_save_netcdf_control". Instead it is called in the main program, immediately after the chemistry calculations, i.e. just after subroutine "uEMEP_chemistry_control", but before the call to "correct_annual_mean_chemistry".
2. In subroutine "correct_annual_mean_chemistry", the relative increase due to the correction in total NO2 and O3 concentration in every grid cell is calculated, and all NO2 and O3 source contributions are multiplied by this factor.
3. In the (unlikely) case that the uncorrected total concentration is zero (absolute value less than epsilon0), do not modify the source contributions.