### PR TITLE
add CAO5 specific setup and update netcdf reader

### DIFF
--- a/src/read_data/uEMEP_read_EMEP.f90
+++ b/src/read_data/uEMEP_read_EMEP.f90
@@ -47,7 +47,7 @@ contains
         integer n_file
         double precision date_num_temp,date_num_2000
         integer date_array(6)
-        double precision scale_factor_nc
+        double precision :: scale_factor_nc, add_offset_nc
 
         integer i_pollutant,p_loop,p_loop_index
 
@@ -339,9 +339,21 @@ contains
                 endif
 
                 status_nc = NF90_INQ_VARID (id_nc, trim(dim_name_nc(x_dim_nc_index)), var_id_nc)
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc,temp_var1d_nc_dp(1,1:2),start=(/1/),count=(/2/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc .ne. NF90_NOERR) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc .ne. NF90_NOERR) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var1d_nc_dp(1,1:2), start=[1], count=[2])
+                temp_var1d_nc_dp(1,1:2) = temp_var1d_nc_dp(1,1:2) * scale_factor_nc + add_offset_nc
+                
                 status_nc = NF90_INQ_VARID (id_nc, trim(dim_name_nc(y_dim_nc_index)), var_id_nc)
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc,temp_var1d_nc_dp(2,1:2),start=(/1/),count=(/2/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc .ne. NF90_NOERR) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc .ne. NF90_NOERR) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var1d_nc_dp(2,1:2), start=[1], count=[2])
+                temp_var1d_nc_dp(2,1:2) = temp_var1d_nc_dp(2,1:2) * scale_factor_nc + add_offset_nc
+
                 status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_name_nc_temp)
                 if (trim(unit_name_nc_temp).eq.'km') then
                     write(unit_logfile,'(A)') 'Units of x y data are in kilometres. Converting to metres'
@@ -456,20 +468,20 @@ contains
                 temp_var4d_nc=0.
             endif
 
-            !write(*,*) x_dim_nc_index,y_dim_nc_index
-            !write(*,*) shape(var1d_nc_dp)
-            !write(*,*) dim_length_nc
             !Read in the dimensions and check values of the dimensions. Not necessary but diagnostic
             do i=1,num_dims_nc
                 status_nc = NF90_INQ_VARID (id_nc, trim(dim_name_nc(i)), var_id_nc)
-                !write(*,*) id_nc, trim(dim_name_nc(i)), var_id_nc(i),dim_length_nc(i)
                 var1d_nc_dp=0.
-                !write(*,*) 'HERE',i,dim_start_nc(i),dim_length_nc(i)
                 unit_dim_nc(i)=''
                 if (status_nc .EQ. NF90_NOERR) then
                     status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc,var1d_nc_dp(1:dim_length_nc(i)),start=(/dim_start_nc(i)/),count=(/dim_length_nc(i)/));var1d_nc(1:dim_length_nc(i),i)=real(var1d_nc_dp(1:dim_length_nc(i)))
-                    !write(*,*) id_nc, trim(dim_name_nc(i)), var_id_nc,dim_length_nc(i),status_nc
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, var1d_nc_dp(1:dim_length_nc(i)), start=[dim_start_nc(i)], count=[dim_length_nc(i)])
+                    var1d_nc_dp(1:dim_length_nc(i)) = var1d_nc_dp(1:dim_length_nc(i)) * scale_factor_nc + add_offset_nc
+                    var1d_nc(1:dim_length_nc(i),i) = real(var1d_nc_dp(1:dim_length_nc(i)))
                     !Use the first file to give valid time stamps
                     if (i_file.eq.1.and.i.eq.time_dim_nc_index) then
                         val_dim_nc(1:dim_length_nc(i),i)=(var1d_nc_dp(1:dim_length_nc(i)))
@@ -478,7 +490,6 @@ contains
                         val_dim_nc(1:dim_length_nc(i),i)=(var1d_nc_dp(1:dim_length_nc(i)))
                         valid_dim_length_nc(i)=dim_length_nc(i)
                     endif
-                    !write(*,*) val_dim_nc(1:dim_length_nc(i),i),trim(unit_dim_nc(i))
                 else
                     var1d_nc(1:dim_length_nc(i),i)=0.
                     val_dim_nc(1:dim_length_nc(i),i)=0.
@@ -549,39 +560,67 @@ contains
 
                             !If a variable name is found in the file then go further
                             if (status_nc.eq.NF90_NOERR) then
-                                scale_factor_nc=1.
                                 !Find the dimensions of the variable (temp_num_dims)
                                 status_nc = NF90_INQUIRE_VARIABLE(id_nc, var_id_nc, ndims = temp_num_dims)
-                                !write(*,*) temp_num_dims,status_nc
                                 if (temp_num_dims.eq.2.and.i_file.eq.1) then
                                     !Read latitude and longitude data into a 2d grid if available. Only lat lon is 2d? Only read for file 1 assuming file 2 is the same. Problem if not
                                     if (i.eq.lat_nc_index.or.i.eq.lon_nc_index) then
-                                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, var2d_nc_dp);var2d_nc(:,:,i)=real(var2d_nc_dp)
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                        if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                        if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, var2d_nc_dp)
+                                        var2d_nc_dp = var2d_nc_dp * scale_factor_nc + add_offset_nc
+                                        var2d_nc(:,:,i) = real(var2d_nc_dp)
                                         write(unit_logfile,'(A,i3,A,2A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(var2d_nc(:,:,i)),maxval(var2d_nc(:,:,i))
                                     endif
                                 elseif (temp_num_dims.eq.3.and.i_file.eq.1.and.i.eq.emis_nc_index.and.i_pollutant.eq.pm10_nc_index.and.i_source.ne.extrasource_nc_index) then
                                     var_name_nc_temp2=var_name_nc(i,pmco_nc_index,i_source)
                                     status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp2), var_id_nc)
                                     if (status_nc .eq. NF90_NOERR) then
-                                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, pm_var3d_nc(:,:,:,i,i_source,1),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                        write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp2),' (min, max): ',minval(pm_var3d_nc(:,:,:,i,i_source,1)),maxval(pm_var3d_nc(:,:,:,i,i_source,1))
-                                        write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp2),sum(pm_var3d_nc(:,:,:,i,i_source,1))/(size(pm_var3d_nc,1)*size(pm_var3d_nc,2)*size(pm_var3d_nc,4))
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                        if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                        if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, pm_var3d_nc(:,:,:,i,i_source,1), &
+                                            start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                            count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                        pm_var3d_nc(:,:,:,i,i_source,1) = pm_var3d_nc(:,:,:,i,i_source,1) * scale_factor_nc + add_offset_nc
+                                        write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp2),' (min, max): ', &
+                                            minval(pm_var3d_nc(:,:,:,i,i_source,1)),maxval(pm_var3d_nc(:,:,:,i,i_source,1))
+                                        write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp2), &
+                                            sum(pm_var3d_nc(:,:,:,i,i_source,1))/(size(pm_var3d_nc,1)*size(pm_var3d_nc,2)*size(pm_var3d_nc,4))
                                     end if
                                     var_name_nc_temp2=var_name_nc(i,pm25_nc_index,i_source)
                                     status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp2), var_id_nc)
                                     if (status_nc .eq. NF90_NOERR) then
-                                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, pm_var3d_nc(:,:,:,i,i_source,2),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                        write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp2),' (min, max): ',minval(pm_var3d_nc(:,:,:,i,i_source,2)),maxval(pm_var3d_nc(:,:,:,i,i_source,2))
-                                        write(unit_logfile,'(2A,f16.4,3i0)') ' Average of: ',trim(var_name_nc_temp2),sum(pm_var3d_nc(:,:,:,i,i_source,2))/(size(pm_var3d_nc,1)*size(pm_var3d_nc,2)*size(pm_var3d_nc,4)),size(pm_var3d_nc,1),size(pm_var3d_nc,2),size(pm_var3d_nc,4)
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                        if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                        if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, pm_var3d_nc(:,:,:,i,i_source,2), &
+                                            start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                            count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                        pm_var3d_nc(:,:,:,i,i_source,2) = pm_var3d_nc(:,:,:,i,i_source,2) * scale_factor_nc + add_offset_nc
+                                        write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp2),' (min, max): ', &
+                                            minval(pm_var3d_nc(:,:,:,i,i_source,2)),maxval(pm_var3d_nc(:,:,:,i,i_source,2))
+                                        write(unit_logfile,'(2A,f16.4,3i0)') ' Average of: ',trim(var_name_nc_temp2), &
+                                            sum(pm_var3d_nc(:,:,:,i,i_source,2))/(size(pm_var3d_nc,1)*size(pm_var3d_nc,2)*size(pm_var3d_nc,4)),size(pm_var3d_nc,1),size(pm_var3d_nc,2),size(pm_var3d_nc,4)
                                     end if
                                     var3d_nc(:,:,:,i,i_source,p_loop_index)=pm_var3d_nc(:,:,:,i,i_source,1)+pm_var3d_nc(:,:,:,i,i_source,2)
-                                    write(unit_logfile,'(2A,f16.4,3i0)') ' Average of: ',trim(var_name_nc(i,pm10_nc_index,i_source)),sum(var3d_nc(:,:,:,i,i_source,p_loop_index))/(size(var3d_nc,1)*size(var3d_nc,2)*size(var3d_nc,4)),size(var3d_nc,1),size(var3d_nc,2),size(var3d_nc,4)
+                                    write(unit_logfile,'(2A,f16.4,3i0)') ' Average of: ',trim(var_name_nc(i,pm10_nc_index,i_source)), &
+                                        sum(var3d_nc(:,:,:,i,i_source,p_loop_index))/(size(var3d_nc,1)*size(var3d_nc,2)*size(var3d_nc,4)),size(var3d_nc,1),size(var3d_nc,2),size(var3d_nc,4)
                                 elseif (temp_num_dims.eq.3.and.i_file.eq.1) then
-                                    !write(*,'(6i)') dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index,dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, var3d_nc(:,:,:,i,i_source,p_loop_index),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    !write(*,*) status_nc
-                                    write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp),' (min, max): ',minval(var3d_nc(:,:,:,i,i_source,p_loop_index)),maxval(var3d_nc(:,:,:,i,i_source,p_loop_index))
-                                    !if (i.eq.emis_nc_index) write(*,*) 'HERE',sum(var3d_nc(:,:,:,i,i_source,p_loop_index)),i_source,p_loop_index
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, var3d_nc(:,:,:,i,i_source,p_loop_index), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    var3d_nc(:,:,:,i,i_source,p_loop_index) = var3d_nc(:,:,:,i,i_source,p_loop_index) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(var3d_nc(:,:,:,i,i_source,p_loop_index)),maxval(var3d_nc(:,:,:,i,i_source,p_loop_index))
                                 elseif (temp_num_dims.eq.4) then
                                     if (i_file.eq.2.and.i.eq.ZTOP_nc_index) then
                                         !Don't try to read
@@ -589,33 +628,52 @@ contains
                                         var_name_nc_temp2=var_name_nc(i,pmco_nc_index,i_source)
                                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp2), var_id_nc)
                                         if (status_nc .eq. 0) then
-                                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,1),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                            write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp2),' (min, max): ',minval(pm_var4d_nc(:,:,:,:,i,i_source,1)),maxval(pm_var4d_nc(:,:,:,:,i,i_source,1))
-                                            write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp2),sum(pm_var4d_nc(:,:,1,:,i,i_source,1))/(size(pm_var4d_nc,1)*size(pm_var4d_nc,2)*size(pm_var4d_nc,4))
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,1), &
+                                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                            pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,1) = &
+                                                pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,1) * scale_factor_nc + add_offset_nc
+                                            write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp2),' (min, max): ', &
+                                                minval(pm_var4d_nc(:,:,:,:,i,i_source,1)),maxval(pm_var4d_nc(:,:,:,:,i,i_source,1))
+                                            write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp2), &
+                                                sum(pm_var4d_nc(:,:,1,:,i,i_source,1))/(size(pm_var4d_nc,1)*size(pm_var4d_nc,2)*size(pm_var4d_nc,4))
                                         end if
                                         var_name_nc_temp2=var_name_nc(i,pm25_nc_index,i_source)
                                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp2), var_id_nc)
                                         if (status_nc .eq. 0) then
-                                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,2),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                            write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp2),' (min, max): ',minval(pm_var4d_nc(:,:,:,:,i,i_source,2)),maxval(pm_var4d_nc(:,:,:,:,i,i_source,2))
-                                            write(unit_logfile,'(2A,f16.4,3i0)') ' Average of: ',trim(var_name_nc_temp2),sum(pm_var4d_nc(:,:,1,:,i,i_source,2))/(size(pm_var4d_nc,1)*size(pm_var4d_nc,2)*size(pm_var4d_nc,4)),size(pm_var4d_nc,1),size(pm_var4d_nc,2),size(pm_var4d_nc,4)
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,2), &
+                                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                            pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,2) = &
+                                                pm_var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,2) * scale_factor_nc + add_offset_nc
+                                            write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp2),' (min, max): ', &
+                                                minval(pm_var4d_nc(:,:,:,:,i,i_source,2)),maxval(pm_var4d_nc(:,:,:,:,i,i_source,2))
+                                            write(unit_logfile,'(2A,f16.4,3i0)') ' Average of: ',trim(var_name_nc_temp2), &
+                                                sum(pm_var4d_nc(:,:,1,:,i,i_source,2))/(size(pm_var4d_nc,1)*size(pm_var4d_nc,2)*size(pm_var4d_nc,4)),size(pm_var4d_nc,1),size(pm_var4d_nc,2),size(pm_var4d_nc,4)
                                         end if
                                         var4d_nc(:,:,:,:,i,i_source,p_loop_index)=pm_var4d_nc(:,:,:,:,i,i_source,1)+pm_var4d_nc(:,:,:,:,i,i_source,2)
                                         write(unit_logfile,'(2A,f16.4,3i0)') ' Average of: ',trim(var_name_nc(i,pm10_nc_index,i_source)),sum(var4d_nc(:,:,:,:,i,i_source,p_loop_index))/(size(var4d_nc,1)*size(var4d_nc,2)*size(var4d_nc,4)),size(var4d_nc,1),size(var4d_nc,2),size(var4d_nc,4)
                                     else
-                                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,p_loop_index),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                        !status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var4d_nc(:,:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                        !var4d_nc(:,:,:,:,i,i_source)=real(temp_var4d_nc(:,:,:,:))
-                                        write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp),' (min, max): ',minval(var4d_nc(:,:,:,:,i,i_source,p_loop_index)),maxval(var4d_nc(:,:,:,:,i,i_source,p_loop_index))
-                                        !if (i.eq.precip_nc_index) then
-                                        !    write(*,*) maxval(var4d_nc(:,:,:,:,i,i_source,p_loop_index))
-                                        !    stop
-                                        !endif
-
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                        if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                        if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,p_loop_index), &
+                                            start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                            count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                        var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,p_loop_index) = &
+                                            var4d_nc(:,:,dim_start_nc(z_dim_nc_index):dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1,:,i,i_source,p_loop_index) * scale_factor_nc + add_offset_nc
+                                        write(unit_logfile,'(A,I0,A,I0,3A,2f16.4)') ' Reading: ',temp_num_dims,' p_loop:',p_loop_index,' ',trim(var_name_nc_temp),' (min, max): ', &
+                                            minval(var4d_nc(:,:,:,:,i,i_source,p_loop_index)),maxval(var4d_nc(:,:,:,:,i,i_source,p_loop_index))
                                     endif
-                                    !write(*,*) shape(var4d_nc)
-                                    !write(*,*) dim_start_nc(z_dim_nc_index),dim_length_nc(z_dim_nc_index)
-                                    !write(*,*) maxval(var4d_nc(:,:,1,1,i,i_source)),maxval(var4d_nc(:,:,1,2,i,i_source))
                                 elseif (temp_num_dims.eq.6.and.i_file.eq.2) then
                                     !if (i.eq.frac_nc_index.and.i_pollutant.eq.pm10_nc_index) then
                                     lc_frac_nc_index=convert_frac_to_lc_frac_loop_index(i)
@@ -624,19 +682,40 @@ contains
                                         var_name_nc_temp2=var_name_nc(i,pmco_nc_index,i_source)
                                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp2), var_id_nc)
                                         if (status_nc .eq. 0) then
-                                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,1),start=(/1,1,dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(xdist_dim_nc_index),dim_length_nc(ydist_dim_nc_index),dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,1), &
+                                                start=[1,1,dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                                count=[dim_length_nc(xdist_dim_nc_index),dim_length_nc(ydist_dim_nc_index),dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                            pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,1) = pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,1) * scale_factor_nc + add_offset_nc
                                             write(unit_logfile,'(A,2I0,3A,2f16.4)') ' Reading: ',i,temp_num_dims,' ',trim(var_name_nc_temp2),' (min, max): ',minval(pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,1)),maxval(pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,1))
                                         end if
                                         var_name_nc_temp2=var_name_nc(i,pm25_nc_index,i_source)
                                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp2), var_id_nc)
                                         if (status_nc .eq. 0) then
-                                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,2),start=(/1,1,dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(xdist_dim_nc_index),dim_length_nc(ydist_dim_nc_index),dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,2), &
+                                                start=[1,1,dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                                count=[dim_length_nc(xdist_dim_nc_index),dim_length_nc(ydist_dim_nc_index),dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                            pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,2) = pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,2) * scale_factor_nc + add_offset_nc
                                             write(unit_logfile,'(A,2I0,3A,2f16.4)') ' Reading: ',i,temp_num_dims,' ',trim(var_name_nc_temp2),' (min, max): ',minval(pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,2)),maxval(pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,2))
                                         end if
                                         !Not used but calculated for writing
                                         !lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,p_loop_index)=pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,1)+pm_lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,2)
                                     else
-                                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,p_loop_index),start=(/1,1,dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)/),count=(/dim_length_nc(xdist_dim_nc_index),dim_length_nc(ydist_dim_nc_index),dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                        if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                        status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                        if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,p_loop_index), &
+                                            start=[1,1,dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)], &
+                                            count=[dim_length_nc(xdist_dim_nc_index),dim_length_nc(ydist_dim_nc_index),dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                        lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,p_loop_index) = lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,p_loop_index) * scale_factor_nc + add_offset_nc
                                         write(unit_logfile,'(A,2I0,3A,2f16.4)') ' Reading: ',i,temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,p_loop_index)),maxval(lc_var4d_nc(:,:,:,:,:,:,lc_frac_nc_index,i_source,p_loop_index))
                                     endif
                                     !write(*,*) shape(lc_var4d_nc)
@@ -667,39 +746,56 @@ contains
                     status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                     !write(*,*) 'Status1: ',status_nc,id_nc,var_id_nc,trim(var_name_nc_temp)
 
-                    !If a variable name is found in the file then go further
+                    ! If a variable name is found in the file then go further
                     if (status_nc.eq.NF90_NOERR) then
 
-                        !Find the dimensions of the variable (temp_num_dims)
+                        ! Find the dimensions of the variable (temp_num_dims)
                         status_nc = NF90_INQUIRE_VARIABLE(id_nc, var_id_nc, ndims = temp_num_dims)
+
+                        ! Get scale factor and offset if present
+                        status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                        if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                        status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                        if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
 
                         if (temp_num_dims.eq.3) then
                             if (i_file.eq.1) then
-                                status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
+                                status_nc = NF90_GET_VAR(id_nc, var_id_nc, temp_var3d_nc(:,:,:), &
+                                    start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                    count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                temp_var3d_nc(:,:,:) = temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
                                 comp_var4d_nc(:,:,surface_level_nc,:,i_conc)=temp_var3d_nc(:,:,:)*comp_scale_nc(i_conc)
-                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 1: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc)),maxval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc))
-                                !write(*,*) comp_var4d_nc(:,:,1,:,i_conc)
+                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 1: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                                    minval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc)),maxval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc))
                             elseif (i_file.eq.2) then
                                 !In case the comp data is in the uEMEP file then read it here with no vertical extent
-                                status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
+                                status_nc = NF90_GET_VAR(id_nc, var_id_nc, temp_var3d_nc(:,:,:), &
+                                    start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                    count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                temp_var3d_nc(:,:,:) = temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
                                 comp_var4d_nc(:,:,surface_level_nc,:,i_conc)=temp_var3d_nc(:,:,:)*comp_scale_nc(i_conc)
-                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 2: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc)),maxval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc))
+                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 2: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                                    minval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc)),maxval(comp_var4d_nc(:,:,surface_level_nc,:,i_conc))
                             endif
                         endif
                         if (temp_num_dims.eq.4) then
                             if (i_file.eq.1) then
-                                !write(*,'(4i)') dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),temp_start_time_nc_index
-                                !write(*,'(4i)') dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)
-
-                                status_nc = NF90_GET_VAR (id_nc, var_id_nc, comp_var4d_nc(:,:,:,:,i_conc),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                comp_var4d_nc(:,:,:,:,i_conc)=comp_var4d_nc(:,:,:,:,i_conc)*comp_scale_nc(i_conc)
-                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 1: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(comp_var4d_nc(:,:,:,:,i_conc)),maxval(comp_var4d_nc(:,:,:,:,i_conc))
-
+                                status_nc = NF90_GET_VAR(id_nc, var_id_nc, comp_var4d_nc(:,:,:,:,i_conc), &
+                                    start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),temp_start_time_nc_index], &
+                                    count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                comp_var4d_nc(:,:,:,:,i_conc) = comp_var4d_nc(:,:,:,:,i_conc) * scale_factor_nc + add_offset_nc
+                                comp_var4d_nc(:,:,:,:,i_conc) = comp_var4d_nc(:,:,:,:,i_conc) * comp_scale_nc(i_conc)
+                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 1: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                                    minval(comp_var4d_nc(:,:,:,:,i_conc)),maxval(comp_var4d_nc(:,:,:,:,i_conc))
                             elseif (i_file.eq.2) then
                                 !In case the comp data is in the uEMEP file then read it here with no vertical extent
-                                status_nc = NF90_GET_VAR (id_nc, var_id_nc, comp_var4d_nc(:,:,1,:,i_conc),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),1,temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),1,dim_length_nc(time_dim_nc_index)/))
-                                comp_var4d_nc(:,:,1,:,i_conc)=comp_var4d_nc(:,:,1,:,i_conc)*comp_scale_nc(i_conc)
-                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 2: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(comp_var4d_nc(:,:,1,:,i_conc)),maxval(comp_var4d_nc(:,:,1,:,i_conc))
+                                status_nc = NF90_GET_VAR(id_nc, var_id_nc, comp_var4d_nc(:,:,1,:,i_conc), &
+                                    start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),1,temp_start_time_nc_index], &
+                                    count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),1,dim_length_nc(time_dim_nc_index)])
+                                comp_var4d_nc(:,:,1,:,i_conc) = comp_var4d_nc(:,:,1,:,i_conc) * scale_factor_nc + add_offset_nc
+                                comp_var4d_nc(:,:,1,:,i_conc) = comp_var4d_nc(:,:,1,:,i_conc) * comp_scale_nc(i_conc)
+                                write(unit_logfile,'(A,I0,3A,2f16.4)') ' Reading compound file 2: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                                    minval(comp_var4d_nc(:,:,1,:,i_conc)),maxval(comp_var4d_nc(:,:,1,:,i_conc))
                             endif
                         endif
 
@@ -721,8 +817,16 @@ contains
 
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, depo_var3d_nc(:,:,:,i_depo,p_loop),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading deposition velocity: ',trim(var_name_nc_temp),' (min, max): ',minval(depo_var3d_nc(:,:,:,i_depo,p_loop)),maxval(depo_var3d_nc(:,:,:,i_depo,p_loop))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, depo_var3d_nc(:,:,:,i_depo,p_loop), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            depo_var3d_nc(:,:,:,i_depo,p_loop) = depo_var3d_nc(:,:,:,i_depo,p_loop) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading deposition velocity: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(depo_var3d_nc(:,:,:,i_depo,p_loop)),maxval(depo_var3d_nc(:,:,:,i_depo,p_loop))
                             !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                         else
                             !write(unit_logfile,'(8A,8A)') ' Cannot read deposition velocity: ',trim(var_name_nc_temp)
@@ -748,27 +852,42 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_asoa_in_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
-                            species_var3d_nc(:,:,:,pmxx_sp_index,sp_asoa_index)=species_temp_var3d_nc(:,:,:)
-                            species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                            !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            species_var3d_nc(:,:,:,pmxx_sp_index,sp_asoa_index) = species_temp_var3d_nc(:,:,:)
+                            species_var3d_nc(:,:,:,pmxx_sp_index,i_sp) = species_temp_var3d_nc(:,:,:)
                         else
-                            write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
+                            write(unit_logfile,'(8A,8A)') ' Cannot read species: ', trim(var_name_nc_temp)
                         endif
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_bsoa_in_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
-                            species_var3d_nc(:,:,:,pmxx_sp_index,sp_bsoa_index)=species_temp_var3d_nc(:,:,:)
-                            species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Adding species: ',trim(species_name_nc(pmxx_sp_index,ii_sp)),' (min, max): ',minval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)),maxval(species_var3d_nc(:,:,:,pm25_sp_index,i_sp))
-                            !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            species_var3d_nc(:,:,:,pmxx_sp_index,sp_bsoa_index) = species_temp_var3d_nc(:,:,:)
+                            species_var3d_nc(:,:,:,pmxx_sp_index,i_sp) = species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Adding species: ',trim(species_name_nc(pmxx_sp_index,ii_sp)),' (min, max): ', &
+                                minval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)),maxval(species_var3d_nc(:,:,:,pm25_sp_index,i_sp))
                         else
-                            write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
+                            write(unit_logfile,'(8A,8A)') ' Cannot read species: ', trim(var_name_nc_temp)
                         endif
-                        species_var3d_nc(:,:,:,pm10_sp_index,i_sp)=species_var3d_nc(:,:,:,pm25_sp_index,i_sp)
+                        species_var3d_nc(:,:,:,pm10_sp_index,i_sp) = species_var3d_nc(:,:,:,pm25_sp_index,i_sp)
 
                     endif
 
@@ -778,10 +897,17 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_sia_in_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                            !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                         endif
@@ -791,10 +917,17 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_no3_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                            !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                         endif
@@ -806,10 +939,17 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_no3_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                            !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                         endif
@@ -819,10 +959,17 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_so4_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                            !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                         endif
@@ -832,10 +979,17 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_nh4_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                            !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                         endif
@@ -857,8 +1011,16 @@ contains
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_dust_sah_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
@@ -866,10 +1028,19 @@ contains
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_dust_wb_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Adding species: ',trim(species_name_nc(pmxx_sp_index,ii_sp)),' (min, max): ',minval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)),maxval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp))
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Adding species: ',trim(species_name_nc(pmxx_sp_index,ii_sp)),' (min, max): ', &
+                                        minval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)),maxval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
@@ -887,7 +1058,14 @@ contains
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_seasalt_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
                                     write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
                                 else
@@ -906,8 +1084,16 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_ffire_bc_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
@@ -915,10 +1101,19 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_ffire_rem_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Adding species: ',trim(species_name_nc(pmxx_sp_index,ii_sp)),' (min, max): ',minval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)),maxval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp))
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Adding species: ',trim(species_name_nc(pmxx_sp_index,ii_sp)),' (min, max): ', &
+                                minval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)),maxval(species_var3d_nc(:,:,:,pmxx_sp_index,i_sp))
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                         endif
@@ -933,10 +1128,17 @@ contains
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_ppm_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
@@ -951,8 +1153,16 @@ contains
                         var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_water_in_index)
                         status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                         if (status_nc.eq.NF90_NOERR) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                            status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                            species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                            write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                             species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
                         else
                             write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
@@ -969,14 +1179,20 @@ contains
                             var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_pm_in_index)
                             status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                             if (status_nc.eq.NF90_NOERR) then
-                                status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                    start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                    count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                    minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                 species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                                !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                             else
                                 write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                             endif
-                            !endif
                         enddo
 
                     endif
@@ -990,38 +1206,56 @@ contains
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_FFIRE_OM_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
-                                !endif
                             enddo
                             do pmxx_sp_index=1,n_pmxx_sp_index
-                                !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_FFIRE_BC_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
-                                !endif
                             enddo
                             do pmxx_sp_index=1,n_pmxx_sp_index
                                 !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_FFIRE_REM_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
@@ -1036,81 +1270,111 @@ contains
                         if (ii_sp.eq.sp_BBOA_RES_index) then
                             !Read total pm
                             do pmxx_sp_index=1,n_pmxx_sp_index
-                                !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_POM_RES_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
-                                !endif
                             enddo
                             do pmxx_sp_index=1,n_pmxx_sp_index
-                                !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_EC_RES_NEW_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
-                                !endif
                             enddo
                             do pmxx_sp_index=1,n_pmxx_sp_index
-                                !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_EC_RES_AGE_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
-                                !endif
                             enddo
                             do pmxx_sp_index=1,n_pmxx_sp_index
-                                !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_REM_RES_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
-                                !endif
                             enddo
                             do pmxx_sp_index=1,n_pmxx_sp_index
-                                !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_EC_RES_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
+                                    write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ', &
+                                        minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
-                                    !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
                                 else
                                     write(unit_logfile,'(8A,8A)') ' Cannot read species: ',trim(var_name_nc_temp)
                                 endif
-                                !endif
                             enddo
                             do pmxx_sp_index=1,n_pmxx_sp_index
-                                !if (pmxx_sp_index.eq.pm25_sp_index.or.pm10_sp_index.eq.pmxx_sp_index) then
                                 var_name_nc_temp=species_name_nc(pmxx_sp_index,sp_EC_RES_in_index)
                                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                                 if (status_nc.eq.NF90_NOERR) then
-                                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, species_temp_var3d_nc(:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, species_temp_var3d_nc(:,:,:), &
+                                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),temp_start_time_nc_index], &
+                                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)])
+                                    species_temp_var3d_nc(:,:,:) = species_temp_var3d_nc(:,:,:) * scale_factor_nc + add_offset_nc
                                     write(unit_logfile,'(A,2A,2f16.4)') ' Reading species: ',trim(var_name_nc_temp),' (min, max): ',minval(species_temp_var3d_nc(:,:,:)),maxval(species_temp_var3d_nc(:,:,:))
                                     species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)=species_var3d_nc(:,:,:,pmxx_sp_index,i_sp)+species_temp_var3d_nc(:,:,:)
                                     !write(unit_logfile,'(2A,f16.4)') ' Average of: ',trim(var_name_nc_temp),sum(species_temp_var3d_nc(:,:,:))/(size(species_temp_var3d_nc,1)*size(species_temp_var3d_nc,2)*size(species_temp_var3d_nc,3))
@@ -1222,7 +1486,14 @@ contains
                 if (calculate_source(heating_index).and.i_file.eq.1) then
                     var_name_nc_temp=var_name_nc(t2m_nc_index,all_nc_index,allsource_nc_index)
                     status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, DMT_EMEP_grid_nc,start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),DMT_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),DMT_dim_length_nc/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, DMT_EMEP_grid_nc, &
+                        start=[dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),DMT_start_time_nc_index], &
+                        count=[dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),DMT_dim_length_nc])
+                    DMT_EMEP_grid_nc = DMT_EMEP_grid_nc * scale_factor_nc + add_offset_nc
                     write(unit_logfile,'(3A,2f16.4)') ' Reading: ',trim(var_name_nc_temp),' (min, max): ',minval(DMT_EMEP_grid_nc),maxval(DMT_EMEP_grid_nc)
                     DMT_EMEP_grid_nc(:,:,1)=sum(DMT_EMEP_grid_nc,3)/DMT_dim_length_nc-273.13
                     write(unit_logfile,'(3A,2f16.4,a,i0)') ' Calculating mean: ',trim(var_name_nc_temp),' (min, max): ',minval(DMT_EMEP_grid_nc(:,:,1)),maxval(DMT_EMEP_grid_nc(:,:,1)),' over this number of time steps: ',DMT_dim_length_nc

--- a/src/read_data/uEMEP_read_SSB_data.f90
+++ b/src/read_data/uEMEP_read_SSB_data.f90
@@ -10,6 +10,8 @@ module read_ssb_data
 
     public :: uEMEP_read_netcdf_population, uEMEP_read_SSB_data, uEMEP_read_netcdf_population_latlon
 
+    double precision :: scale_factor_nc, add_offset_nc
+
 contains
 
 !uEMEP_read_SSB_data.f90
@@ -410,12 +412,6 @@ contains
         endif
 
         !Find the projection. If no projection then in lat lon coordinates
-        !status_nc = NF90_INQ_VARID (id_nc,'projection_lambert',var_id_nc)
-        !status_nc = NF90_INQ_VARID (id_nc,'mollweide',var_id_nc_temp)
-        !if (status_nc.eq.NF90_NOERR) then
-        !    population_nc_projection_type=mollweide_projection_index
-        !    var_id_nc=var_id_nc_temp
-        !endif
         status_nc = NF90_INQ_VARID (id_nc,'transverse_mercator',var_id_nc_temp)
         if (status_nc.eq.NF90_NOERR) then
             population_nc_projection_type=UTM_projection_index
@@ -477,8 +473,12 @@ contains
             var_name_nc_temp=dim_name_population_nc(i)
             status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
             if (status_nc .EQ. NF90_NOERR) then
-                !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc, var2d_nc_dp(1:dim_length_population_nc(i),i),start=(/1/),count=(/dim_length_population_nc(i)/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR(id_nc, var_id_nc, var2d_nc_dp(1:dim_length_population_nc(i),i), start=[1], count=[dim_length_population_nc(i)])
+                var2d_nc_dp(1:dim_length_population_nc(i),i) = var2d_nc_dp(1:dim_length_population_nc(i),i) * scale_factor_nc + add_offset_nc
             else
                 write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
             endif
@@ -492,8 +492,13 @@ contains
             var_name_nc_temp=var_name_population_nc(i)
             status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
             if (status_nc .EQ. NF90_NOERR) then
-                !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc, population_nc_dp(:,:,i),start=(/1,1/),count=(/dim_length_population_nc(x_dim_nc_index),dim_length_population_nc(y_dim_nc_index)/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR (id_nc, var_id_nc, population_nc_dp(:,:,i), &
+                    start=[1,1], count=[dim_length_population_nc(x_dim_nc_index),dim_length_population_nc(y_dim_nc_index)])
+                population_nc_dp(:,:,i) = population_nc_dp(:,:,i) * scale_factor_nc + add_offset_nc
                 write(unit_logfile,'(2a,2f12.2)') 'Population variable min and max: ',trim(var_name_nc_temp),minval(population_nc_dp(:,:,i)),maxval(population_nc_dp(:,:,i))
             else
                 write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
@@ -710,8 +715,13 @@ contains
                 var_name_nc_temp=dim_name_population_nc(i)
                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                 if (status_nc .EQ. NF90_NOERR) then
-                    !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var2d_nc_dp(1:dim_length_population_nc(i),i),start=(/dim_start_population_nc(i)/),count=(/dim_length_population_nc(i)/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, temp_var2d_nc_dp(1:dim_length_population_nc(i),i), &
+                        start=[dim_start_population_nc(i)], count=[dim_length_population_nc(i)])
+                    temp_var2d_nc_dp(1:dim_length_population_nc(i),i) = temp_var2d_nc_dp(1:dim_length_population_nc(i),i) * scale_factor_nc + add_offset_nc
                 else
                     write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
                 endif
@@ -766,8 +776,13 @@ contains
                 var_name_nc_temp=dim_name_population_nc(i)
                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                 if (status_nc .EQ. NF90_NOERR) then
-                    !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, var2d_nc_dp(1:dim_length_population_nc(i),i),start=(/dim_start_population_nc(i)/),count=(/dim_length_population_nc(i)/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, var2d_nc_dp(1:dim_length_population_nc(i),i), &
+                        start=[dim_start_population_nc(i)], count=[dim_length_population_nc(i)])
+                    var2d_nc_dp(1:dim_length_population_nc(i),i) = var2d_nc_dp(1:dim_length_population_nc(i),i) * scale_factor_nc + add_offset_nc
                 else
                     write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
                 endif
@@ -786,8 +801,14 @@ contains
             var_name_nc_temp=var_name_population_nc(i)
             status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
             if (status_nc .EQ. NF90_NOERR) then
-                !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc, population_nc_dp(:,:,population_nc_index),start=(/dim_start_population_nc(x_dim_nc_index),dim_start_population_nc(y_dim_nc_index)/),count=(/dim_length_population_nc(x_dim_nc_index),dim_length_population_nc(y_dim_nc_index)/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR(id_nc, var_id_nc, population_nc_dp(:,:,population_nc_index), &
+                    start=[dim_start_population_nc(x_dim_nc_index),dim_start_population_nc(y_dim_nc_index)], &
+                    count=[dim_length_population_nc(x_dim_nc_index),dim_length_population_nc(y_dim_nc_index)])
+                population_nc_dp(:,:,population_nc_index) = population_nc_dp(:,:,population_nc_index) * scale_factor_nc + add_offset_nc
                 write(unit_logfile,'(2a,2f12.2)') 'Population variable min and max: ',trim(var_name_nc_temp),minval(population_nc_dp(:,:,population_nc_index)),maxval(population_nc_dp(:,:,population_nc_index))
             else
                 write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc

--- a/src/read_data/uEMEP_read_config.f90
+++ b/src/read_data/uEMEP_read_config.f90
@@ -775,6 +775,9 @@ contains
             read_RWC_file_with_extra_HDD=read_name_logical('read_RWC_file_with_extra_HDD',read_RWC_file_with_extra_HDD,unit_in,unit_logfile)
             read_RWC_file_with_extra_HDD_and_height=read_name_logical('read_RWC_file_with_extra_HDD_and_height',read_RWC_file_with_extra_HDD_and_height,unit_in,unit_logfile)
 
+            ! Benzene splits from VOC
+            benzene_split_voc_in_GNFR_sectors(13) = read_name_real("benzene_split_voc_in_GNFR_sectors(13)", benzene_split_voc_in_GNFR_sectors(13), unit_in, unit_logfile)
+
             !Allows a scaling of EMEP input ozone. For testing.
             comp_scale_nc(o3_nc_index)=read_name_real('comp_scale_nc(o3_nc_index)',comp_scale_nc(o3_nc_index),unit_in,unit_logfile)
             comp_scale_nc(nox_nc_index)=read_name_real('comp_scale_nc(nox_nc_index)',comp_scale_nc(nox_nc_index),unit_in,unit_logfile)

--- a/src/read_data/uEMEP_read_landuse_rivm_data.f90
+++ b/src/read_data/uEMEP_read_landuse_rivm_data.f90
@@ -26,6 +26,8 @@ module read_landuse_rivm_data
     parameter (n_corine_landuse_index=48)
     integer Corine_to_EMEP_landuse(n_corine_landuse_index)
 
+    double precision :: scale_factor_nc, add_offset_nc
+
 contains
 
 !uEMEP_read_landuse_rivm_data.f90
@@ -290,8 +292,12 @@ contains
                 var_name_nc_temp=dim_name_landuse_nc(i)
                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                 if (status_nc .EQ. NF90_NOERR) then
-                    !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var2d_nc_dp(1:dim_length_landuse_nc(i),i),start=(/dim_start_landuse_nc(i)/),count=(/dim_length_landuse_nc(i)/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, temp_var2d_nc_dp(1:dim_length_landuse_nc(i),i), start=[dim_start_landuse_nc(i)], count=[dim_length_landuse_nc(i)])
+                    temp_var2d_nc_dp(1:dim_length_landuse_nc(i),i) = temp_var2d_nc_dp(1:dim_length_landuse_nc(i),i) * scale_factor_nc + add_offset_nc
                 else
                     write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
                 endif
@@ -345,8 +351,12 @@ contains
                 var_name_nc_temp=dim_name_landuse_nc(i)
                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                 if (status_nc .EQ. NF90_NOERR) then
-                    !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, var2d_nc_dp(1:dim_length_landuse_nc(i),i),start=(/dim_start_landuse_nc(i)/),count=(/dim_length_landuse_nc(i)/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, var2d_nc_dp(1:dim_length_landuse_nc(i),i), start=[dim_start_landuse_nc(i)], count=[dim_length_landuse_nc(i)])
+                    var2d_nc_dp(1:dim_length_landuse_nc(i),i) = var2d_nc_dp(1:dim_length_landuse_nc(i),i) * scale_factor_nc + add_offset_nc
                 else
                     write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
                 endif
@@ -363,8 +373,14 @@ contains
             var_name_nc_temp=var_name_landuse_nc(i)
             status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
             if (status_nc .EQ. NF90_NOERR) then
-                !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc, landuse_nc_dp(:,:),start=(/dim_start_landuse_nc(x_dim_nc_index),dim_start_landuse_nc(y_dim_nc_index)/),count=(/dim_length_landuse_nc(x_dim_nc_index),dim_length_landuse_nc(y_dim_nc_index)/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR(id_nc, var_id_nc, landuse_nc_dp(:,:), &
+                    start=[dim_start_landuse_nc(x_dim_nc_index),dim_start_landuse_nc(y_dim_nc_index)], &
+                    count=[dim_length_landuse_nc(x_dim_nc_index),dim_length_landuse_nc(y_dim_nc_index)])
+                landuse_nc_dp(:,:) = landuse_nc_dp(:,:) * scale_factor_nc + add_offset_nc
                 write(unit_logfile,'(2a,2f12.2)') 'Landuse variable min and max: ',trim(var_name_nc_temp),minval(landuse_nc_dp(:,:)),maxval(landuse_nc_dp(:,:))
             else
                 write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc

--- a/src/read_data/uEMEP_read_meteo_nc.f90
+++ b/src/read_data/uEMEP_read_meteo_nc.f90
@@ -49,7 +49,7 @@ contains
         integer n_file,n_file_start
         double precision date_num_temp
         integer date_array(6)
-        double precision scale_factor_nc
+        double precision :: scale_factor_nc, add_offset_nc
 
         logical found_file
         integer :: search_hour_step=6
@@ -340,13 +340,23 @@ contains
                 !write(*,*) temp_x_min,temp_x_max,temp_y_min,temp_y_max
 
                 status_nc = NF90_INQ_VARID (id_nc, trim(dim_name_meteo_nc(x_dim_nc_index)), var_id_nc)
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc,temp_var1d_nc_dp(1,1:2),start=(/1/),count=(/2/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR(id_nc, var_id_nc, temp_var1d_nc_dp(1,1:2), start=[1],count=[2])
+                temp_var1d_nc_dp(1,1:2) = temp_var1d_nc_dp(1,1:2) * scale_factor_nc + add_offset_nc
                 status_nc = NF90_INQ_VARID (id_nc, trim(dim_name_meteo_nc(y_dim_nc_index)), var_id_nc)
-                status_nc = NF90_GET_VAR (id_nc, var_id_nc,temp_var1d_nc_dp(2,1:2),start=(/1/),count=(/2/))
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                status_nc = NF90_GET_VAR(id_nc, var_id_nc, temp_var1d_nc_dp(2,1:2), start=[1], count=[2])
+                temp_var1d_nc_dp(2,1:2) = temp_var1d_nc_dp(2,1:2) * scale_factor_nc + add_offset_nc
                 status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_name_nc_temp)
                 if (trim(unit_name_nc_temp).eq.'km') then
                     write(unit_logfile,'(A)') 'Units of x y data are in kilometres. Converting to metres'
-                    temp_var1d_nc_dp=temp_var1d_nc_dp*1000.
+                    temp_var1d_nc_dp = temp_var1d_nc_dp * 1000.0
                 endif
 
                 !HERE FIX. The EMEP_grid_interpolation_size is too small when using EMEP is a different grid to the meteo grid. Need to rescale this somehow
@@ -435,7 +445,13 @@ contains
                 unit_dim_meteo_nc(i)=''
                 if (status_nc .EQ. NF90_NOERR) then
                     status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc,var1d_nc_dp(1:dim_length_meteo_nc(i)),start=(/dim_start_meteo_nc(i)/),count=(/dim_length_meteo_nc(i)/));meteo_var1d_nc(1:dim_length_meteo_nc(i),i)=real(var1d_nc_dp(1:dim_length_meteo_nc(i)))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, var1d_nc_dp(1:dim_length_meteo_nc(i)), start=[dim_start_meteo_nc(i)], count=[dim_length_meteo_nc(i)])
+                    var1d_nc_dp(1:dim_length_meteo_nc(i)) = var1d_nc_dp(1:dim_length_meteo_nc(i)) * scale_factor_nc + add_offset_nc
+                    meteo_var1d_nc(1:dim_length_meteo_nc(i),i)=real(var1d_nc_dp(1:dim_length_meteo_nc(i)))
                     !Use the first file to give valid time stamps
                     if (i_file.eq.3.and.i.eq.time_dim_nc_index) then
                         val_dim_meteo_nc(1:dim_length_meteo_nc(i),i)=real(var1d_nc_dp(1:dim_length_meteo_nc(i)))
@@ -476,60 +492,60 @@ contains
 
                 !If a variable name is found in the file then go further
                 if (status_nc.eq.NF90_NOERR) then
-                    scale_factor_nc=1.
                     !Find the dimensions of the variable (temp_num_dims)
                     status_nc = NF90_INQUIRE_VARIABLE(id_nc, var_id_nc, ndims = temp_num_dims)
-                    !write(*,*) temp_num_dims,status_nc
+
+                    ! Find scale factor and offset if present
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+
                     if (temp_num_dims.eq.2.and.i_file.eq.3) then
                         !Read latitude and longitude data into a 2d grid if available. Only lat lon is 2d?
                         if (i.eq.lat_nc_index.or.i.eq.lon_nc_index) then
-                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, var2d_nc_dp);meteo_var2d_nc(:,:,i)=real(var2d_nc_dp)
-                            write(unit_logfile,'(A,i3,A,2A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(meteo_var2d_nc(:,:,i)),maxval(meteo_var2d_nc(:,:,i))
+                            status_nc = NF90_GET_VAR (id_nc, var_id_nc, var2d_nc_dp)
+                            var2d_nc_dp = var2d_nc_dp * scale_factor_nc + add_offset_nc
+                            meteo_var2d_nc(:,:,i)=real(var2d_nc_dp)
+                            write(unit_logfile,'(A,i3,A,2A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                                minval(meteo_var2d_nc(:,:,i)),maxval(meteo_var2d_nc(:,:,i))
                         endif
                     elseif (temp_num_dims.eq.3.and.i_file.eq.4) then
                         !Special case for z0 file as they are scaled integers and a single time file
-                        !write(*,'(6i)') dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(time_dim_nc_index),dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(time_dim_nc_index)
-                        status_nc = nf90_get_att(id_nc, var_id_nc, "scale_factor", scale_factor_nc)
-                        if (status_nc.ne.NF90_NOERR) scale_factor_nc=1.
-                        !write(*,*) 'scale_factor=',scale_factor_nc
-                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, meteo_var3d_nc(:,:,1,i),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)/))
-                        meteo_var3d_nc(:,:,:,i)=real(meteo_var3d_nc(:,:,:,i)*scale_factor_nc)
-                        !write(*,*) status_nc
+                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, meteo_var3d_nc(:,:,1,i), &
+                            start=[dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)], &
+                            count=[dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)])
+                        meteo_var3d_nc(:,:,1,i) = meteo_var3d_nc(:,:,1,i) * scale_factor_nc + add_offset_nc
                         write(unit_logfile,'(A,I,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(meteo_var3d_nc(:,:,1:dim_length_meteo_nc(time_dim_nc_index),i)),maxval(meteo_var3d_nc(:,:,1:dim_length_meteo_nc(time_dim_nc_index),i))
                     elseif (temp_num_dims.eq.4.and.i_file.eq.3) then
-                        !write(*,*) dim_start_nc(z_dim_nc_index),dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1
-                        !write(*,*) dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)
-                        !write(*,*) dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)
-                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)-1/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(z_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)+1/))
-                        !status_nc = NF90_GET_VAR (id_nc, var_id_nc, meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,dim_start_meteo_nc(time_dim_nc_index)-1:dim_start_meteo_nc(time_dim_nc_index)+dim_length_meteo_nc(time_dim_nc_index)-1,i),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)-1/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(z_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)+1/))
-                        !status_nc = NF90_GET_VAR (id_nc, var_id_nc, meteo_var4d_nc(:,:,1,dim_start_meteo_nc(time_dim_nc_index):dim_length_meteo_nc(time_dim_nc_index),i),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),1,dim_start_meteo_nc(time_dim_nc_index)/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),1,dim_length_meteo_nc(time_dim_nc_index)/))
-                        !status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var4d_nc(:,:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                        !var4d_nc(:,val_dim_nc:,:,:,i,i_source)=real(temp_var4d_nc(:,:,:,:))
-                        write(unit_logfile,'(A,I,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i)),maxval(meteo_var4d_nc(1:dim_length_meteo_nc(x_dim_nc_index),1:dim_length_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i))
-                        !write(*,*) dim_start_meteo_nc(time_dim_nc_index)-1,dim_length_meteo_nc(time_dim_nc_index)+1,dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1
+                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i), &
+                            start=[dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)-1], &
+                            count=[dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(z_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)+1])
+                        meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i) = &
+                            meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i) * scale_factor_nc + add_offset_nc
+                        write(unit_logfile,'(A,I,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                            minval(meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i)), &
+                            maxval(meteo_var4d_nc(1:dim_length_meteo_nc(x_dim_nc_index),1:dim_length_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i))
                     elseif (temp_num_dims.eq.3.and.i_file.eq.3) then
                         !NBV meteo data
-                        status_nc = nf90_get_att(id_nc, var_id_nc, "scale_factor", scale_factor_nc)
-                        if (status_nc.ne.NF90_NOERR) scale_factor_nc=1.
-                        !write(*,*) dim_start_nc(z_dim_nc_index),dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1
-                        !write(*,*) dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)
-                        !write(*,*) dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)
-                        !status_nc = NF90_GET_VAR (id_nc, var_id_nc, meteo_var4d_nc(:,:,1,:,i),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)-1/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)+1/))
-                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, meteo_var4d_nc(:,:,1,dim_start_meteo_nc(time_dim_nc_index):dim_length_meteo_nc(time_dim_nc_index),i),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)/))
-                        !status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var4d_nc(:,:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                        meteo_var4d_nc(:,:,:,:,i)=real(meteo_var4d_nc(:,:,:,:,i)*scale_factor_nc)
-                        write(unit_logfile,'(A,I,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(meteo_var4d_nc(:,:,1,1:dim_length_meteo_nc(time_dim_nc_index),i)),maxval(meteo_var4d_nc(1:dim_length_meteo_nc(x_dim_nc_index),1:dim_length_meteo_nc(y_dim_nc_index),1,1:dim_length_meteo_nc(time_dim_nc_index),i))
-                        !write(*,*) dim_start_meteo_nc(time_dim_nc_index)-1,dim_length_meteo_nc(time_dim_nc_index)+1,dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1
+                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, meteo_var4d_nc(:,:,1,dim_start_meteo_nc(time_dim_nc_index):dim_length_meteo_nc(time_dim_nc_index),i), &
+                            start=[dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)], &
+                            count=[dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)])
+                        meteo_var4d_nc(:,:,1,dim_start_meteo_nc(time_dim_nc_index):dim_length_meteo_nc(time_dim_nc_index),i) = &
+                            meteo_var4d_nc(:,:,1,dim_start_meteo_nc(time_dim_nc_index):dim_length_meteo_nc(time_dim_nc_index),i) * scale_factor_nc + add_offset_nc
+                        write(unit_logfile,'(A,I,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                            minval(meteo_var4d_nc(:,:,1,1:dim_length_meteo_nc(time_dim_nc_index),i)), &
+                            maxval(meteo_var4d_nc(1:dim_length_meteo_nc(x_dim_nc_index),1:dim_length_meteo_nc(y_dim_nc_index),1,1:dim_length_meteo_nc(time_dim_nc_index),i))
                     elseif (temp_num_dims.eq.5.and.i_file.eq.3) then
                         !This is the case when there is an ensemble member in the format
-                        !write(*,*) dim_start_nc(z_dim_nc_index),dim_start_nc(z_dim_nc_index)+dim_length_nc(z_dim_nc_index)-1
-                        !write(*,*) dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),dim_start_nc(time_dim_nc_index)
-                        !write(*,*) dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)
-                        status_nc = NF90_GET_VAR (id_nc, var_id_nc, meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),1,dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)-1/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),1,dim_length_meteo_nc(z_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)+1/))
-                        !status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var4d_nc(:,:,:,:),start=(/dim_start_nc(x_dim_nc_index),dim_start_nc(y_dim_nc_index),dim_start_nc(z_dim_nc_index),temp_start_time_nc_index/),count=(/dim_length_nc(x_dim_nc_index),dim_length_nc(y_dim_nc_index),dim_length_nc(z_dim_nc_index),dim_length_nc(time_dim_nc_index)/))
-                        !var4d_nc(:,val_dim_nc:,:,:,i,i_source)=real(temp_var4d_nc(:,:,:,:))
-                        write(unit_logfile,'(A,I,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i)),maxval(meteo_var4d_nc(1:dim_length_meteo_nc(x_dim_nc_index),1:dim_length_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i))
-                        !write(*,*) dim_start_meteo_nc(time_dim_nc_index)-1,dim_length_meteo_nc(time_dim_nc_index)+1,dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1
+                        status_nc = NF90_GET_VAR(id_nc, var_id_nc, meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i), &
+                            start=[dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),1,dim_start_meteo_nc(z_dim_nc_index),dim_start_meteo_nc(time_dim_nc_index)-1], &
+                            count=[dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),1,dim_length_meteo_nc(z_dim_nc_index),dim_length_meteo_nc(time_dim_nc_index)+1])
+                        meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i) = &
+                            meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,:,i) * scale_factor_nc + add_offset_nc
+                        write(unit_logfile,'(A,I,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ', &
+                            minval(meteo_var4d_nc(:,:,dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i)), &
+                            maxval(meteo_var4d_nc(1:dim_length_meteo_nc(x_dim_nc_index),1:dim_length_meteo_nc(y_dim_nc_index),dim_start_meteo_nc(z_dim_nc_index):dim_start_meteo_nc(z_dim_nc_index)+dim_length_meteo_nc(z_dim_nc_index)-1,1:dim_length_meteo_nc(time_dim_nc_index),i))
                     else
                         write(unit_logfile,'(8A,8A)') ' Cannot find a correct dimension for: ',trim(var_name_nc_temp)
                     endif
@@ -557,6 +573,12 @@ contains
                     var_name_nc_temp=var_name_meteo_nc(t2m_nc_index)
                     status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                     status_nc = NF90_INQUIRE_VARIABLE(id_nc, var_id_nc, ndims = temp_num_dims)
+
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    
                     if (temp_num_dims.eq.4) then
                         status_nc = NF90_GET_VAR (id_nc, var_id_nc, DMT_EMEP_grid_nc(:,:,:),start=(/dim_start_meteo_nc(x_dim_nc_index),dim_start_meteo_nc(y_dim_nc_index),1,DMT_start_time_nc_index/),count=(/dim_length_meteo_nc(x_dim_nc_index),dim_length_meteo_nc(y_dim_nc_index),1,DMT_dim_length_nc/))
                     elseif (temp_num_dims.eq.3) then
@@ -567,6 +589,8 @@ contains
                     else
                         write(unit_logfile,'(8A,8A)') ' Cannot find a correct dimension for: ',trim(var_name_nc_temp)
                     endif
+
+                    DMT_EMEP_grid_nc(:,:,:) = DMT_EMEP_grid_nc(:,:,:) * scale_factor_nc + add_offset_nc
 
                     write(unit_logfile,'(A,i,3A,2f16.4)') ' Reading: ',temp_num_dims,' ',trim(var_name_nc_temp),' (min, max): ',minval(DMT_EMEP_grid_nc),maxval(DMT_EMEP_grid_nc)
                     DMT_EMEP_grid_nc(:,:,1)=sum(DMT_EMEP_grid_nc,3)/DMT_dim_length_nc-273.13

--- a/src/read_data/uEMEP_read_shipping_asi_data.f90
+++ b/src/read_data/uEMEP_read_shipping_asi_data.f90
@@ -13,6 +13,8 @@ module read_shipping_asi_data
         uEMEP_read_weekly_shipping_asi_data, uEMEP_read_monthly_and_daily_shipping_asi_data, &
         uEMEP_read_shipping_asi_data
 
+    double precision :: scale_factor_nc, add_offset_nc
+
 contains
 
 !uEMEP_read_shipping_asi_data.f90
@@ -616,8 +618,13 @@ contains
                 var_name_nc_temp=dim_name_shipping_nc(i)
                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                 if (status_nc .EQ. NF90_NOERR) then
-                    !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, temp_var2d_nc_dp(1:dim_length_shipping_nc(i),i),start=(/dim_start_shipping_nc(i)/),count=(/dim_length_shipping_nc(i)/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, temp_var2d_nc_dp(1:dim_length_shipping_nc(i),i), &
+                        start=[dim_start_shipping_nc(i)], count=[dim_length_shipping_nc(i)])
+                    temp_var2d_nc_dp(1:dim_length_shipping_nc(i),i) = temp_var2d_nc_dp(1:dim_length_shipping_nc(i),i) * scale_factor_nc + add_offset_nc
                 else
                     write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
                 endif
@@ -672,8 +679,13 @@ contains
                 var_name_nc_temp=dim_name_shipping_nc(i)
                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                 if (status_nc .EQ. NF90_NOERR) then
-                    !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, var2d_nc_dp(1:dim_length_shipping_nc(i),i),start=(/dim_start_shipping_nc(i)/),count=(/dim_length_shipping_nc(i)/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, var2d_nc_dp(1:dim_length_shipping_nc(i),i), &
+                        start=[dim_start_shipping_nc(i)], count=[dim_length_shipping_nc(i)])
+                    var2d_nc_dp(1:dim_length_shipping_nc(i),i) = var2d_nc_dp(1:dim_length_shipping_nc(i),i) * scale_factor_nc + add_offset_nc
                 else
                     write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc
                 endif
@@ -689,8 +701,14 @@ contains
                 var_name_nc_temp=var_name_shipping_nc(i_ship)
                 status_nc = NF90_INQ_VARID (id_nc, trim(var_name_nc_temp), var_id_nc)
                 if (status_nc .EQ. NF90_NOERR) then
-                    !status_nc = nf90_get_att(id_nc, var_id_nc, "units", unit_dim_meteo_nc(i))
-                    status_nc = NF90_GET_VAR (id_nc, var_id_nc, shipping_nc_dp(:,:,i_ship),start=(/dim_start_shipping_nc(x_dim_nc_index),dim_start_shipping_nc(y_dim_nc_index)/),count=(/dim_length_shipping_nc(x_dim_nc_index),dim_length_shipping_nc(y_dim_nc_index)/))
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+                    if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+                    status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+                    if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+                    status_nc = NF90_GET_VAR(id_nc, var_id_nc, shipping_nc_dp(:,:,i_ship), &
+                        start=[dim_start_shipping_nc(x_dim_nc_index),dim_start_shipping_nc(y_dim_nc_index)], &
+                        count=[dim_length_shipping_nc(x_dim_nc_index),dim_length_shipping_nc(y_dim_nc_index)])
+                    shipping_nc_dp(:,:,i_ship) = shipping_nc_dp(:,:,i_ship) * scale_factor_nc + add_offset_nc
                     write(unit_logfile,'(2a,2f12.2)') 'Shipping variable min and max: ',trim(var_name_nc_temp),minval(shipping_nc_dp(:,:,i_ship)),maxval(shipping_nc_dp(:,:,i_ship))
                 else
                     write(unit_logfile,'(A,A,A,I)') 'No information available for ',trim(var_name_nc_temp),' Status: ',status_nc

--- a/src/save_data/uEMEP_save_netcdf_file.f90
+++ b/src/save_data/uEMEP_save_netcdf_file.f90
@@ -325,7 +325,7 @@ contains
                         else
                             if (i_source.eq.traffic_index.and.(pollutant_loop_index(i_pollutant).eq.pm10_index.or.pollutant_loop_index(i_pollutant).eq.pm25_index)) then
                                 ! Special case for traffic pm: In some setups we need to subtract exhaust to get non-exhaust
-                                if (pollutant_index.eq.all_totals_nc_index.or.pollutant_index.eq.aaqd_totals_nc_index.or.pollutant_index.eq.gp_totals_nc_index.or.pollutant_index.eq.op_totals_nc_index) then
+                                if (pollutant_index.eq.all_totals_nc_index.or.pollutant_index.eq.aaqd_totals_nc_index.or.pollutant_index.eq.gp_totals_nc_index.or.pollutant_index.eq.op_totals_nc_index.or.pollutant_index.eq.cao5_nc_index) then
                                     ! Traffic exhaust is not a separate pollutant, so just save total traffic
                                     var_name_temp=trim(var_name_nc(conc_nc_index,pollutant_loop_index(i_pollutant),allsource_index))//'_'//trim(filename_grid(i_file))//trim(filename_append)
                                     if (source_domain_loop == 1) then

--- a/src/uEMEP_auto_subgrid.f90
+++ b/src/uEMEP_auto_subgrid.f90
@@ -12,6 +12,8 @@ module auto_subgrid
 
     public :: uEMEP_auto_subgrid, uEMEP_region_mask, uEMEP_interpolate_auto_subgrid, uEMEP_region_mask_new
 
+    double precision :: scale_factor_nc, add_offset_nc
+
 contains
 
     subroutine uEMEP_auto_subgrid()
@@ -620,7 +622,12 @@ contains
         ! x
         status_nc = NF90_INQ_VARID (id_nc, trim(x_dim_name_regionmask), var_id_nc)
         if (status_nc == NF90_NOERR) then
-            status_nc = NF90_GET_VAR (id_nc,var_id_nc,x_values_regionmask)
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+            status_nc = NF90_GET_VAR(id_nc, var_id_nc, x_values_regionmask)
+            x_values_regionmask = x_values_regionmask * scale_factor_nc + add_offset_nc
         else
             write(unit_logfile,'(A)') 'Error while reading x values from region mask'
             stop
@@ -628,7 +635,12 @@ contains
         ! y
         status_nc = NF90_INQ_VARID (id_nc, trim(y_dim_name_regionmask), var_id_nc)
         if (status_nc == NF90_NOERR) then
-            status_nc = NF90_GET_VAR (id_nc,var_id_nc,y_values_regionmask)
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+            status_nc = NF90_GET_VAR (id_nc, var_id_nc, y_values_regionmask)
+            y_values_regionmask = y_values_regionmask * scale_factor_nc + add_offset_nc
         else
             write(unit_logfile,'(A)') 'Error while reading y values from region mask'
             stop
@@ -774,7 +786,12 @@ contains
         ! x
         status_nc = NF90_INQ_VARID (id_nc, trim(x_dim_name_regionmask), var_id_nc)
         if (status_nc == NF90_NOERR) then
-            status_nc = NF90_GET_VAR (id_nc,var_id_nc,x_values_regionmask,start=(/x_min_index/),count=(/nx_regionmask/))
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+            status_nc = NF90_GET_VAR(id_nc, var_id_nc, x_values_regionmask, start=[x_min_index], count=[nx_regionmask])
+            x_values_regionmask = x_values_regionmask * scale_factor_nc + add_offset_nc
         else
             write(unit_logfile,'(A)') 'Error while reading x values from region mask'
             stop
@@ -782,7 +799,12 @@ contains
         ! y
         status_nc = NF90_INQ_VARID (id_nc, trim(y_dim_name_regionmask), var_id_nc)
         if (status_nc == NF90_NOERR) then
-            status_nc = NF90_GET_VAR (id_nc,var_id_nc,y_values_regionmask,start=(/y_min_index/),count=(/ny_regionmask/))
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'scale_factor', scale_factor_nc)
+            if (status_nc /= nf90_noerr) scale_factor_nc = 1.0d0
+            status_nc = nf90_get_att(id_nc, var_id_nc, 'add_offset', add_offset_nc)
+            if (status_nc /= nf90_noerr) add_offset_nc = 0.0d0
+            status_nc = NF90_GET_VAR(id_nc, var_id_nc, y_values_regionmask, start=[y_min_index], count=[ny_regionmask])
+            y_values_regionmask = y_values_regionmask * scale_factor_nc + add_offset_nc
         else
             write(unit_logfile,'(A)') 'Error while reading y values from region mask'
             stop
@@ -793,7 +815,7 @@ contains
         if (status_nc == NF90_NOERR) then
             status_nc = NF90_INQUIRE_VARIABLE(id_nc, var_id_nc, ndims = temp_num_dims)
             ! NB: the following line fails if the region_mask subset is bigger than ca. 1 million elements when runnning interactively, but not as a qsub job (fix by increasing 'ulimit -s', e.g. 'ulimit -s unlimited')
-            status_nc = NF90_GET_VAR (id_nc, var_id_nc, region_mask, start=(/x_min_index, y_min_index/), count=(/nx_regionmask,ny_regionmask/))
+            status_nc = NF90_GET_VAR(id_nc, var_id_nc, region_mask, start=[x_min_index,y_min_index], count=[nx_regionmask,ny_regionmask])
             write(unit_logfile,'(A,i3,A,2A,2i16)') ' Reading: ',temp_num_dims,' ',trim(varname_region_mask),' (min, max): ',minval(region_mask),maxval(region_mask)
         else
             write(unit_logfile,'(A)') 'Could not read region mask values from file'

--- a/src/uEMEP_definitions.f90
+++ b/src/uEMEP_definitions.f90
@@ -124,6 +124,7 @@ module uEMEP_definitions
     integer, parameter :: aaqd_totals_nc_index = 28
     integer, parameter :: gp_totals_nc_index = 29
     integer, parameter :: op_totals_nc_index = 30
+    integer, parameter :: cao5_nc_index = 31
 
     ! These must be the same as the subgrid source indexes. Should probably just use the one
     integer, parameter :: allsource_nc_index = 1
@@ -156,7 +157,7 @@ module uEMEP_definitions
 
     ! Loop for all pollutants to be calculated
     integer :: pollutant_index
-    integer, parameter :: n_pollutant_nc_index = 30 ! Includes the addition naming indexes index
+    integer, parameter :: n_pollutant_nc_index = 31 ! Includes the addition naming indexes index
     integer :: n_pollutant_loop = 1
     integer :: n_emep_pollutant_loop = 1
     integer :: pollutant_loop_index(n_pollutant_nc_index)

--- a/src/uEMEP_set_constants.f90
+++ b/src/uEMEP_set_constants.f90
@@ -780,7 +780,6 @@ contains
             pollutant_loop_back_index(pm10_nc_index) = 3
             pollutant_loop_back_index(bap_nc_index) = 4
             pollutant_loop_back_index(c6h6_nc_index) = 5
-            extract_benzene_from_voc_emissions = .true.
         elseif (pollutant_index.eq.pm_nc_index) then
             n_emep_pollutant_loop=2
             n_pollutant_loop=3

--- a/src/uEMEP_set_constants.f90
+++ b/src/uEMEP_set_constants.f90
@@ -104,6 +104,8 @@ contains
         var_name_nc(conc_nc_index,gp_totals_nc_index,allsource_nc_index)='gp_totals'
         var_name_nc(conc_nc_index,op_totals_nc_index,allsource_nc_index)='op_totals'
 
+        var_name_nc(conc_nc_index,cao5_nc_index,allsource_nc_index)='cao5'
+
         var_name_nc(conc_nc_index,pm25_sand_nc_index,allsource_nc_index)='pm25_sand'
         var_name_nc(conc_nc_index,pm10_sand_nc_index,allsource_nc_index)='pm10_sand'
         var_name_nc(conc_nc_index,pm25_salt_nc_index,allsource_nc_index)='pm25_salt'
@@ -765,6 +767,20 @@ contains
             pollutant_loop_back_index(nox_nc_index)=1
             pollutant_loop_back_index(pm25_nc_index)=2
             pollutant_loop_back_index(pm10_nc_index)=3
+        elseif (pollutant_index .eq. cao5_nc_index) then
+            n_emep_pollutant_loop = 5
+            n_pollutant_loop = 5
+            pollutant_loop_index(1) = nox_nc_index
+            pollutant_loop_index(2) = pm25_nc_index
+            pollutant_loop_index(3) = pm10_nc_index
+            pollutant_loop_index(4) = bap_nc_index
+            pollutant_loop_index(5) = c6h6_nc_index
+            pollutant_loop_back_index(nox_nc_index) = 1
+            pollutant_loop_back_index(pm25_nc_index) = 2
+            pollutant_loop_back_index(pm10_nc_index) = 3
+            pollutant_loop_back_index(bap_nc_index) = 4
+            pollutant_loop_back_index(c6h6_nc_index) = 5
+            extract_benzene_from_voc_emissions = .true.
         elseif (pollutant_index.eq.pm_nc_index) then
             n_emep_pollutant_loop=2
             n_pollutant_loop=3


### PR DESCRIPTION
- Adds CAO5 to the compounds list
- Sets reading benzene directly as the default for CAO5
- Changes the EMEP netcdf reader to handle offset and scaling